### PR TITLE
Make standard output the default output

### DIFF
--- a/cobra/controller/configurationVersion.go
+++ b/cobra/controller/configurationVersion.go
@@ -50,6 +50,9 @@ func ConfigurationVersionCmd() *cobra.Command {
 
 	aid.SetConfigurationVersionFlags(cmd)
 
+	cmd.SetOut(os.Stdout)
+	cmd.SetErr(os.Stderr)
+
 	return cmd
 }
 


### PR DESCRIPTION
*Description of changes:*
Currently I'm not able to output some of the commands outputs into an external file. The reason is because at the code we are using the command output rather than the terminal output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
