### PR TITLE
Switch to standalone cobra-cli dependency

### DIFF
--- a/lib/make/cobra/Makefile
+++ b/lib/make/cobra/Makefile
@@ -4,7 +4,7 @@
 .PHONY: cobra/add
 cobra/add: ## Add a Cobra command
 ifdef command
-	cd cobra && cobra add $(command)
+	cd cobra && cobra-cli add $(command)
 else
 	@echo "command not defined"
 endif
@@ -20,5 +20,5 @@ endif
 
 .PHONY: cobra/install
 cobra/install:
-	go get github.com/spf13/cobra/cobra
+	go install github.com/spf13/cobra-cli@latest
 


### PR DESCRIPTION
Switches to use the extracted cobra-cli command since it is being removed from the github.com/spf13/cobra module (xref https://github.com/spf13/cobra/issues/1597)