### PR TITLE
chore: inclusive language — replace master/whitelist/blacklist terminology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ reported the issue. Please try to include as much information as you can. Detail
 
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the _master_ branch.
+1. You are working against the latest source on the _main_ branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![GitHub issues](https://img.shields.io/github/issues/awslabs/tecli)](https://github.com/awslabs/tecli/issues)
 [![GitHub forks](https://img.shields.io/github/forks/awslabs/tecli)](https://github.com/awslabs/tecli/network)
 [![GitHub stars](https://img.shields.io/github/stars/awslabs/tecli)](https://github.com/awslabs/tecli/stargazers)
-[![GitHub license](https://img.shields.io/github/license/awslabs/tecli)](https://github.com/awslabs/tecli/blob/master/LICENSE)
+[![GitHub license](https://img.shields.io/github/license/awslabs/tecli)](https://github.com/awslabs/tecli/blob/main/LICENSE)
 [![Twitter](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Fawslabs%2Ftecli)](https://twitter.com/intent/tweet?text=Wow:&url=https%3A%2F%2Fgithub.com%2Fawslabs%2Ftecli)
 
 </div>

--- a/clencli/readme.yaml
+++ b/clencli/readme.yaml
@@ -14,7 +14,7 @@ shields:
       url: https://github.com/awslabs/tecli/stargazers
     - description: GitHub license
       image: https://img.shields.io/github/license/awslabs/tecli
-      url: https://github.com/awslabs/tecli/blob/master/LICENSE
+      url: https://github.com/awslabs/tecli/blob/main/LICENSE
     - description: Twitter
       image: https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Fawslabs%2Ftecli
       url: https://twitter.com/intent/tweet?text=Wow:&url=https%3A%2F%2Fgithub.com%2Fawslabs%2Ftecli

--- a/cobra/aid/workspace.go
+++ b/cobra/aid/workspace.go
@@ -82,7 +82,7 @@ func SetVCSRepoFlags(cmd *cobra.Command) {
 	// created without a VCS repo. If included, you must specify at least the
 	// oauth-token-id and identifier keys below.`
 
-	usage := `The repository branch that Terraform will execute from. If omitted or submitted as an empty string, this defaults to the repository's default branch (e.g. master).`
+	usage := `The repository branch that Terraform will execute from. If omitted or submitted as an empty string, this defaults to the repository's default branch (e.g. main).`
 	cmd.Flags().String("vcs-repo-branch", "", usage)
 
 	usage = `A reference to your VCS repository in the format :org/:repo where :org and :repo refer to the organization and repository in your VCS provider. The format for Azure DevOps is :org/:project/_git/:repo.`


### PR DESCRIPTION
## Summary

Inclusive-language sweep across the repo per Amazon's inclusive language guidance. The repository's GitHub default branch is already `main`, so updated URLs continue to resolve (verified via HTTP).

No `slave`, `whitelist`, `blacklist`, `whiteday`, or `blackday` occurrences were found in the codebase — only stray `master` references remained, all in docs/strings (no code identifiers).

## Files touched

| File | Change |
|------|--------|
| `README.md` | License badge URL: `/blob/master/LICENSE` → `/blob/main/LICENSE` |
| `CONTRIBUTING.md` | Contributor instructions: `_master_ branch` → `_main_ branch` |
| `clencli/readme.yaml` | License badge URL: `/blob/master/LICENSE` → `/blob/main/LICENSE` |
| `cobra/aid/workspace.go` | CLI help text example: `(e.g. master)` → `(e.g. main)` (purely documentation; no flag/identifier renamed) |

## Intentionally left as-is

- **`helper/files.go:130`** — comment `// https://github.com/mactsouk/opensource.com/blob/master/cp2.go` is a third-party attribution. The upstream repo's `/main/` URL returns 404; only `/master/` resolves. Replacing it would break the link, so it stays.
- **No code identifiers, flags, or APIs were renamed.** The CLI surface is unchanged — no breaking change. (No code-level `master`/`slave`/`whitelist`/`blacklist` symbols existed to begin with.)

## Verification

- `go build ./...` — passes
- `go vet ./...` — pre-existing failure in `tests/cmd_workspace_test.go:42` (`undefined: executeCommand`), unrelated to this change. Confirmed present on the parent branch before this commit.

## Test plan

- [x] Verify all updated URLs resolve (HTTP 200 / valid redirect)
- [x] `go build ./...` succeeds
- [x] No new `go vet` warnings introduced
- [ ] Reviewer sanity-check that the kept third-party URL really requires `/master/`