### PR TITLE
fix: workspace find-by-name correctly handles paginated orgs (#12)

### DIFF
--- a/cobra/controller/workspace.go
+++ b/cobra/controller/workspace.go
@@ -130,17 +130,21 @@ func workspaceRun(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("no workspace was found")
 		}
 	case "find-by-name":
-		organization := dao.GetOrganization(profile)
-		list, err := workspaceList(client, organization, tfe.WorkspaceListOptions{})
-		if err == nil {
-			w, err := workspaceFindByName(list, cmd)
-			if err != nil {
-				return err
-			}
-			fmt.Println(aid.ToJSON(w))
-		} else {
-			return fmt.Errorf("no workspace was found")
+		name, err := cmd.Flags().GetString("name")
+		if err != nil {
+			return err
 		}
+
+		organization := dao.GetOrganization(profile)
+		// Use the exact-name Read endpoint (GET /organizations/{org}/workspaces/{name})
+		// instead of listing and filtering client-side. The list endpoint paginates
+		// at 20 results per page by default, which previously caused workspaces past
+		// the first page to report as "not found". See issue #12.
+		w, err := workspaceFindByName(client, organization, name)
+		if err != nil {
+			return fmt.Errorf("workspace %s not found\n%v", name, err)
+		}
+		fmt.Println(aid.ToJSON(w))
 	case "create":
 		organization := dao.GetOrganization(profile)
 		options := aid.GetWorkspaceCreateOptions(cmd)
@@ -323,20 +327,14 @@ func workspaceList(client *tfe.Client, organization string, options tfe.Workspac
 	return client.Workspaces.List(context.Background(), organization, &options)
 }
 
-func workspaceFindByName(list *tfe.WorkspaceList, cmd *cobra.Command) (*tfe.Workspace, error) {
-
-	name, err := cmd.Flags().GetString("name")
-	if err != nil {
-		return &tfe.Workspace{}, fmt.Errorf("unable to get flag name")
+// workspaceFindByName looks up a workspace by exact name using the
+// dedicated read endpoint, which avoids the 20-per-page pagination
+// limit of the list endpoint that caused issue #12.
+func workspaceFindByName(client *tfe.Client, organization, name string) (*tfe.Workspace, error) {
+	if name == "" {
+		return nil, fmt.Errorf("workspace name is required")
 	}
-
-	for _, item := range list.Items {
-		if item.Name == name {
-			return item, nil
-		}
-	}
-
-	return &tfe.Workspace{}, fmt.Errorf("workspace %s not found", name)
+	return client.Workspaces.Read(context.Background(), organization, name)
 }
 
 // Create is used to create a new workspace.


### PR DESCRIPTION
## Original bug (issue #12)

Reporter (Rosalind-Fletcher) ran:

```sh
tecli workspace find-by-name --name=${TFC_WORKSPACE_NAME} > workspace.json 2>error.txt || true
```

and intermittently got `not found / no workspace was found` even though the workspace existed. Their org had 40+ workspaces and the Terraform Cloud list API paginates at 20 per page, so any workspace that hadn't been recently updated dropped off page 1. They worked around it by bumping the Terraform version in the UI to push the workspace back to the top of the list.

## Reproduction

Any TFC organization with more than 20 workspaces:

1. Run `tecli workspace find-by-name --name=<a-workspace-not-on-page-1>`
2. Observe `workspace <name> not found`, even though the workspace exists and `tecli workspace read --name=<same>` succeeds.

## Root cause

`cobra/controller/workspace.go` `find-by-name` did:

```go
list, err := workspaceList(client, organization, tfe.WorkspaceListOptions{}) // empty options -> page 1, 20 items
w, err := workspaceFindByName(list, cmd) // iterates list.Items
```

That is, it listed page 1 of the workspaces and filtered client-side. There was no pagination loop and no server-side `Search` filter. Anything past page 1 was silently invisible. The bug is unrelated to the go-tfe SDK — it survived the v0.15.0 → v1.108.0 migration unchanged.

## Fix

Use the dedicated exact-name endpoint that the SDK already exposes and that `workspace read` already uses:

```go
client.Workspaces.Read(ctx, organization, name)
// GET /organizations/{org}/workspaces/{name}
```

This is a single direct lookup, returns the same `*tfe.Workspace` shape, has no pagination involvement, and matches the user's intent. It is strictly faster than list+filter (one request, no full-org enumeration).

`find-by-name` and `read` now share the same lookup primitive but remain separate subcommands for backwards compatibility (scripts in the wild call `find-by-name`).

## Why not paginate the list?

Pagination would also work, but it requires up to N round-trips for an org with 20*N workspaces, only to find one workspace by exact name — which is exactly what the `Read` endpoint does in one request. The dedicated endpoint is the right answer.

## Testing

- `go build ./...` — passes
- `go vet ./cobra/...` — clean (the `tests/` package has a pre-existing `executeCommand` undefined error unrelated to this change)
- No new unit tests: the existing `tests/` package requires live TFC credentials. Adding a mocked test would mean introducing an HTTP server fake just for this one method, which is out of scope for a surgical fix. Manual verification requires a TFC org with 20+ workspaces.

Closes #12

---
Modernization 2026-06 sweep