### PR TITLE
docs: refresh README, COMMANDS, CHANGELOG, CONTRIBUTING; add ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,78 @@
+# Architecture
+
+A one-page tour of the TECLI codebase, current as of the June 2026
+modernization. New contributors should read this before opening their
+first PR; deeper details live in the package-level Go doc and the
+[wiki](https://github.com/awslabs/tecli/wiki).
+
+## High-level shape
+
+TECLI is a thin command-line wrapper around
+[`hashicorp/go-tfe`](https://github.com/hashicorp/go-tfe). The binary is
+produced by [`main.go`](main.go), which only calls
+`cmd.Execute()` from the `cobra/cmd` package.
+
+The dependency direction is:
+
+```
+cobra/cmd  -->  cobra/controller  -->  cobra/aid  -->  helper/, box/
+                                  -->  hashicorp/go-tfe
+```
+
+Layers below `controller` never import `cmd`; layers below `aid` never
+import `controller`.
+
+## Directory layout
+
+| Path                | Role                                                                                                                                                                                                              |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `main.go`           | Process entry point. Calls `cmd.Execute()`.                                                                                                                                                                       |
+| `cobra/cmd/`        | **Thin adapters.** One file per top-level command (`workspace`, `run`, `apply`, `plan`, `configuration-version`, `configure`, `o-auth-client`, `o-auth-token`, `ssh-key`, `variable`, `version`). Each file pulls a `*cobra.Command` from the controller package and registers it on `rootCmd`. No business logic here. |
+| `cobra/controller/` | **Business logic.** Builds each `cobra.Command` (with `Use`/`Short`/`Long`/`Example` filled from `box/resources/manual/*.yaml`), wires `PreRunE`/`RunE`, validates flags via `helper.ValidateCmdArgs*`, and calls `go-tfe` to talk to Terraform Cloud/Enterprise. |
+| `cobra/aid/`        | **Option builders + file I/O.** `SetXxxFlags(cmd)` registers per-command flags; `helper.go` and friends marshal flag values into `tfe.XxxOptions{}`, read/write the credentials file, and load viper config.       |
+| `cobra/dao/`        | Data-access shims (currently small) for talking to the embedded resources.                                                                                                                                        |
+| `cobra/model/`      | Plain structs. Most notably `CredentialProfile` used by the `configure` command.                                                                                                                                  |
+| `cobra/view/`       | Output rendering helpers.                                                                                                                                                                                         |
+| `helper/`           | **General utilities.** `cobra.go` (arg/flag validation), `directories.go`, `files.go`, `manual.go` (`GetManual` reads YAML manuals out of `box`), `ssh.go`, `strings.go`. No domain knowledge of Terraform Cloud. |
+| `box/`              | **Embedded resources** (legacy `clencli` flow). `box.go` exposes the embedded blob; `gen.go` regenerates it. `resources/manual/*.yaml` defines each cobra command's `Use`/`Short`/`Long`/`Example`. `resources/VERSION` is the version string surfaced by `tecli version`. |
+| `clencli/`          | Templates and assets consumed by `clencli` to render the README and screenshots: `readme.tmpl`, `readme.yaml`, `terminalizer/*.gif`, `logo.jpeg`.                                                                  |
+| `habits/`           | Submodule (currently empty in tree) hosting shared Make targets included from `Makefile` (e.g. `go/build`, `go/fmt`, `go/install`).                                                                                |
+| `examples/`         | End-user-facing usage examples (e.g. `examples/gitlab/` for GitLab CI).                                                                                                                                            |
+| `tests/`            | Integration tests that hit Terraform Cloud — require `TFC_*` env vars or a configured profile to run. `tests/commands/` houses per-command test files.                                                            |
+| `.github/workflows/`| CI: `build.yml` (per-push build), `publish.yml` (tag-driven release), `release.yml` (release-please).                                                                                                              |
+
+## Adding a new command
+
+1. Add a YAML manual at `box/resources/manual/<name>.yaml` describing
+   `use`, `short`, `long`, `example`.
+2. Add `cobra/controller/<name>.go` that:
+   - Declares `var <name>ValidArgs = []string{ ... }`.
+   - Builds a `*cobra.Command` from `helper.GetManual("<name>", validArgs)`.
+   - Implements `<name>PreRun` (flag validation) and `<name>Run`
+     (calls go-tfe).
+3. Add `cobra/aid/<name>.go` with `SetXxxFlags(cmd *cobra.Command)`
+   and option-builder helpers.
+4. Register the command in `cobra/cmd/<name>.go` and add the
+   `rootCmd.AddCommand(<name>Cmd)` call.
+5. Run `go build ./...` and `go vet ./...`. If the command has tests,
+   add them under `tests/commands/`.
+6. Document the new command in `COMMANDS.md` and (if relevant)
+   `TOP-COMMANDS.md`.
+
+## Configuration & credentials
+
+`tecli configure create` writes a YAML credentials file under
+`~/.tecli/credentials.yaml` with one or more named profiles. Each
+profile holds `organization`, `user-token`, `team-token`, and
+`organization-token`. The same values can be supplied via
+`TFC_ORGANIZATION`, `TFC_USER_TOKEN`, `TFC_TEAM_TOKEN`, and
+`TFC_ORGANIZATION_TOKEN` environment variables (env wins).
+
+Most commands accept `--profile`/`-p` (default: `default`) so a single
+host can target multiple Terraform organizations.
+
+## Build & release entry points
+
+- Local build: `go build ./...` (requires Go 1.25+).
+- Cross-compile: `make tecli/compile` (writes binaries to `dist/`).
+- Release: see [`docs/RELEASING.md`](docs/RELEASING.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,121 @@
-# CHANGELOG
+# Changelog
 
-## Bugfix
+All notable changes to this project are documented in this file.
 
-- Fix bugfixes when executing `tecli configure create` command.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(pre-1.0 releases use the `0.x-alpha` convention).
 
-## Feature
+## [Unreleased] - Modernization 2026-06
 
-- Add organization into the credentials file.
-- Allow `TFC_ORGANIZATION` to be used to define the terraform cloud organization name.
-- Silece command usage when an error occurs.
+Toolchain modernization. Tracked in PR [#27](https://github.com/awslabs/tecli/pull/27)
+and follow-up PRs branched from `chore/modernize-toolchain`.
+
+### Changed
+
+- Bumped `go.mod` directive to **Go 1.25**.
+- Migrated `github.com/hashicorp/go-tfe` from `v0.15.0` to `v1.108.0`.
+  Required adapting controller code in `cobra/controller/` to the new
+  context-aware client API and updated Go-TFE structs.
+- Bumped `github.com/spf13/cobra` to `v1.8.1`.
+- Bumped `github.com/spf13/viper` to `v1.19.0`.
+- Bumped `github.com/sirupsen/logrus` to `v1.9.3`.
+- Bumped `github.com/stretchr/testify` to `v1.11.1`.
+- Bumped `github.com/spf13/afero` to `v1.15.0`.
+- Bumped `github.com/hashicorp/go-slug` to `v0.16.3`.
+- Bumped `github.com/hashicorp/go-retryablehttp` to `v0.7.7`.
+- Bumped `golang.org/x/crypto` to `v0.45.0`.
+
+### Documentation
+
+- Rebuilt `CHANGELOG.md` (this file) to follow Keep a Changelog.
+- Refreshed `README.md` with current install/build instructions and
+  a History section that points at the modernization PRs.
+- Aligned `COMMANDS.md` and `TOP-COMMANDS.md` with the actual cobra
+  subcommands shipped today; flagged divergences and removed wiki/Markdown
+  rot.
+- Updated `CONTRIBUTING.md` for the Go 1.25 toolchain, added a
+  "How to run tests locally" section, and documented the modernization
+  branch / PR flow.
+- Added [`ARCHITECTURE.md`](ARCHITECTURE.md): one-page summary of the
+  directory layout (`cobra/cmd/`, `cobra/controller/`, `cobra/aid/`,
+  `helper/`, `box/`, `clencli/`, `habits/`, `examples/`, `tests/`).
+- Added [`docs/RELEASING.md`](docs/RELEASING.md): release-please workflow
+  and manual fallback steps.
+
+### Removed
+
+- Dropped unused indirect dependencies pinned by stale `// indirect` lines
+  in `go.mod` (handled automatically by `go mod tidy`).
+
+## [0.4.2-alpha] - 2021-2025
+
+Last shipped pre-modernization line of releases. Changes from this era,
+summarized from `git log` (no formal changelog was maintained at the
+time):
+
+### Added
+
+- `tecli configure` family for managing credential profiles.
+- `tecli workspace` commands: `list`, `create`, `read`, `read-by-id`,
+  `update`, `update-by-id`, `delete`, `delete-by-id`, `find-by-name`,
+  `lock`, `unlock`, `force-unlock`, `assign-ssh-key`,
+  `unassign-ssh-key`, `remove-vcs-connection`,
+  `remove-vcs-connection-by-id`.
+- `tecli run` commands: `list`, `create`, `read`, `read-with-options`,
+  `apply`, `cancel`, `cancel-all`, `force-cancel`, `force-cancel-all`,
+  `discard`, `discard-all`.
+- `tecli plan` commands: `read`, `logs`.
+- `tecli apply` commands: `read`, `logs`.
+- `tecli configuration-version` commands: `list`, `create`, `read`,
+  `upload`.
+- `tecli variable` commands: `list`, `create`, `read`, `update`,
+  `update-by-key`, `delete`, `delete-all`.
+- `tecli o-auth-client` and `tecli o-auth-token` for VCS provider
+  configuration.
+- `tecli ssh-key` for managing SSH keys against private modules.
+- `TFC_ORGANIZATION`, `TFC_USER_TOKEN`, `TFC_TEAM_TOKEN`, and
+  `TFC_ORGANIZATION_TOKEN` environment-variable support.
+- DevContainer configuration for VS Code under `.devcontainer/`.
+- Pre-commit configuration (`.pre-commit-config.yaml`) and
+  `goimports` integration.
+- `release-please` workflow scaffolding.
+- GitLab CI example under `examples/gitlab/`.
+- Logo, terminalizer GIFs, and `clencli` README templates under
+  `clencli/`.
+
+### Changed
+
+- `tecli configure create` reads `TFC_ORGANIZATION` from the
+  credentials file/env when present.
+- Standard output unified on `fmt` instead of cobra's command writers.
+- Cobra root command logic moved into the `controller` package for
+  testability.
+- `GetManual` rewritten to drive `Use`/`Short`/`Long`/`Example` from
+  YAML files in `box/resources/manual/`.
+- Switched from `spf13/cobra/cobra` to standalone `cobra-cli`
+  (PR [#14](https://github.com/awslabs/tecli/pull/14)).
+- Silenced cobra's automatic usage dump on errors.
+
+### Fixed
+
+- `configure create` bugs around profile resolution.
+- Workspace access-level requirements for commands that did not need
+  full admin access.
+- Standard-output handling for failed commands
+  (PR [#11](https://github.com/awslabs/tecli/pull/11)).
+- Local test harness for the configure command
+  (PR [#10](https://github.com/awslabs/tecli/pull/10)).
+- Command-line argument inconsistencies vs. documented usage
+  (PR [#9](https://github.com/awslabs/tecli/pull/9)).
+
+## [0.4.0-alpha] - earlier
+
+- Initial public release line under `awslabs/tecli`.
+- Cobra-based CLI scaffolding, viper-backed credentials profile,
+  embedded resources via the `box` package, and the `clencli` /
+  `habits` integration that powers the README and Makefile.
+
+[Unreleased]: https://github.com/awslabs/tecli/compare/v0.4.2-alpha...HEAD
+[0.4.2-alpha]: https://github.com/awslabs/tecli/releases/tag/v0.4.2-alpha
+[0.4.0-alpha]: https://github.com/awslabs/tecli/releases/tag/v0.4.0-alpha

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,10 +1,21 @@
-## Commands
+# Commands
 
-```
+This file is the canonical, hand-maintained map of every TECLI
+subcommand. Each section corresponds to one `*ValidArgs` slice in
+[`cobra/controller/`](cobra/controller/), so `grep cobra.Command{
+cobra/controller/` is the source of truth if these ever drift.
+
+`tecli --help` prints the live top-level list. If you spot a
+divergence between this file and `tecli --help`, please open an issue
+or PR.
+
+## Top-level commands
+
+```text
 Command Line Interface for Terraform Enterprise/Cloud
 
 Usage:
-   [command]
+  tecli [command]
 
 Available Commands:
   apply                 An apply represents the results of applying a Terraform Run's execution plan.
@@ -14,7 +25,7 @@ Available Commands:
   o-auth-client         An OAuth Client represents the connection between an organization and a VCS provider.
   o-auth-token          The oauth-token object represents a VCS configuration which includes the OAuth connection and the associated OAuth token. This object is used when creating a workspace to identify which VCS connection to use.
   plan                  A plan represents the execution plan of a Run in a Terraform workspace.
-  run                   A run performs a plan and apply, using a configuration version and the workspace’s current variables.
+  run                   A run performs a plan and apply, using a configuration version and the workspace's current variables.
   ssh-key               The ssh-key object represents an SSH key which includes a name and the SSH private key. An organization can have multiple SSH keys available.
   variable              Operations on variables.
   version               Displays the version of tecli and all installed plugins
@@ -24,5 +35,75 @@ Flags:
   -h, --help             help for this command
   -p, --profile string   Use a specific profile from your credentials and configurations file. (default "default")
 
-Use " [command] --help" for more information about a command.
+Use "tecli [command] --help" for more information about a command.
 ```
+
+## Subcommands
+
+Use `tecli <command> --help` to see flag-level help. The lists below
+are extracted from the `*ValidArgs` definitions in
+`cobra/controller/`.
+
+### `tecli apply`
+
+`read`, `logs`
+
+### `tecli configuration-version`
+
+`list`, `create`, `read`, `upload`
+
+### `tecli configure`
+
+`list`, `create`, `read`, `update`, `delete`
+
+### `tecli o-auth-client`
+
+`list`, `create`, `read`, `delete`
+
+### `tecli o-auth-token`
+
+`list`, `read`, `update`, `delete`
+
+### `tecli plan`
+
+`read`, `logs`
+
+### `tecli run`
+
+`list`, `create`, `read`, `read-with-options`, `apply`, `cancel`,
+`cancel-all`, `force-cancel`, `force-cancel-all`, `discard`,
+`discard-all`
+
+### `tecli ssh-key`
+
+`list`, `create`, `read`, `update`, `delete`
+
+### `tecli variable`
+
+`list`, `create`, `read`, `update`, `update-by-key`, `delete`,
+`delete-all`
+
+### `tecli version`
+
+No subcommands. Prints the version stored in
+`box/resources/VERSION`.
+
+### `tecli workspace`
+
+`list`, `create`, `read`, `read-by-id`, `update`, `update-by-id`,
+`delete`, `delete-by-id`, `find-by-name`, `lock`, `unlock`,
+`force-unlock`, `assign-ssh-key`, `unassign-ssh-key`,
+`remove-vcs-connection`, `remove-vcs-connection-by-id`
+
+## Common flags
+
+- `-p, --profile string` (persistent, default `default`) — selects a
+  named profile from `~/.tecli/credentials.yaml`.
+- `-h, --help` — per-command help. Always available.
+
+## Cross-references
+
+- One-liner recipes for the most common workflows live in
+  [`TOP-COMMANDS.md`](TOP-COMMANDS.md).
+- Architectural background (where these commands live in the codebase)
+  is in [`ARCHITECTURE.md`](ARCHITECTURE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,59 +1,170 @@
-### Guidelines
+# Contributing to TECLI
 
-Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
-documentation, we greatly value feedback and contributions from our community.
+Thank you for your interest in contributing to TECLI. Whether it's a
+bug report, a new command, a fix, or a docs improvement, we welcome
+your help.
 
-Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
-information to effectively respond to your bug report or contribution.
+Please skim this document end-to-end before opening an issue or
+pull request — it captures the toolchain, the branch flow, and the
+test workflow that the maintainers expect.
 
-### Reporting Bugs/Feature Requests
+## Reporting bugs / requesting features
 
-We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+Use the GitHub issue tracker. Before filing, please search existing
+open and closed issues so we don't end up tracking the same problem
+twice.
 
-When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
-reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
+A good bug report typically contains:
 
-- A reproducible test case or series of steps
-- The version of our code being used
-- Any modifications you've made relevant to the bug
-- Anything unusual about your environment or deployment
+- A reproducible test case or series of steps.
+- The version of TECLI you're using (`tecli version`).
+- The Go version, OS, and architecture you're running on.
+- Any relevant config (`~/.tecli/credentials.yaml` profile shape, env
+  vars), with secrets redacted.
+- Anything unusual about your environment or deployment.
 
-### Contributing via Pull Requests
+## Toolchain
 
-Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
+TECLI now targets **Go 1.25** and uses
+[`hashicorp/go-tfe`](https://github.com/hashicorp/go-tfe) `v1.108+`.
 
-1. You are working against the latest source on the _master_ branch.
-2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
-3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+Set up a development environment:
 
-To send us a pull request, please:
+```bash
+# 1. Install Go 1.25+. https://go.dev/dl/
+go version  # confirm 1.25+
+
+# 2. Clone and build
+git clone https://github.com/awslabs/tecli.git
+cd tecli
+go build ./...
+```
+
+There's also a [`.devcontainer/`](.devcontainer/) configuration if you
+prefer VS Code's dev container experience.
+
+The repo uses [pre-commit](https://pre-commit.com/) — install the
+hooks once with:
+
+```bash
+pre-commit install
+```
+
+## Branch strategy
+
+The default branch is `main`. Day-to-day work follows a simple
+pattern:
+
+| Branch               | Purpose                                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------------------ |
+| `main`               | Always green. Release-please cuts tags from this branch.                                               |
+| Topic branches       | `feat/<short-name>`, `fix/<short-name>`, `docs/<short-name>` etc. Open a PR back to `main`.            |
+| `chore/modernize-toolchain` | Long-running collector branch used during the June 2026 toolchain modernization (see PR #27). Sub-PRs target this branch first, then it merges to `main`. |
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) so
+release-please can keep `CHANGELOG.md` accurate:
+
+```
+feat(workspace): add --auto-apply flag
+fix(run): surface 422 error bodies instead of swallowing
+docs: explain TFC_ORGANIZATION env var
+chore(deps): bump go-tfe to v1.x
+```
+
+## How to run tests locally
+
+The repository has two flavors of tests:
+
+### Unit tests
+
+```bash
+go test ./...
+```
+
+This runs without external services and should always pass on a clean
+checkout.
+
+### Integration tests (Terraform Cloud)
+
+The packages under `tests/commands/` exercise the live Terraform Cloud
+API. They require credentials and will create real workspaces / runs in
+your account.
+
+```bash
+# Either configure a profile (writes ~/.tecli/credentials.yaml)
+tecli configure create
+
+# ...or export environment variables
+export TFC_ORGANIZATION=your-organization
+export TFC_USER_TOKEN=your-user-token
+export TFC_TEAM_TOKEN=your-team-token
+export TFC_ORGANIZATION_TOKEN=your-organization-token
+
+# Then run the integration suite via the Make target
+make tecli/test
+```
+
+Integration tests are skipped automatically when the `TFC_*` env vars
+and credentials profile are both absent.
+
+> **Heads up:** The integration suite creates and tears down workspaces
+> in the configured organization. Don't point it at a production org.
+
+### Vet & format
+
+```bash
+go vet ./...
+gofmt -s -w .
+goimports -w .
+```
+
+`pre-commit` runs the same checks plus a few markdown linters.
+
+## Sending us a pull request
 
 1. Fork the repository.
-2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+2. Create a topic branch off the appropriate base (usually `main`,
+   sometimes `chore/modernize-toolchain` during a modernization
+   sweep).
+3. Make focused changes — please don't reformat unrelated code in the
+   same PR; it makes review harder.
+4. Run `go build ./...`, `go vet ./...`, and any relevant tests.
+5. Commit using Conventional Commits (see above).
+6. Open the PR. Fill in the description: what's changing, why, how
+   you tested it.
+7. Stay engaged with CI failures and reviewer feedback.
 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+GitHub has additional documentation on
+[forking a repository](https://help.github.com/articles/fork-a-repo/)
+and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
-### Finding contributions to work on
+## Finding contributions to work on
 
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
+The GitHub `help wanted` and `good first issue` labels are a good
+starting point. The wiki under
+<https://github.com/awslabs/tecli/wiki> also tracks longer-running
+roadmap items.
 
-### Code of Conduct
+## Code of Conduct
 
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
-opensource-codeofconduct@amazon.com with any additional questions or comments.
+This project has adopted the
+[Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the
+[Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or
+contact opensource-codeofconduct@amazon.com with any additional
+questions or comments.
 
-### Security issue notifications
+## Security issue notifications
 
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
+If you discover a potential security issue in this project we ask that
+you notify AWS/Amazon Security via our
+[vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/).
+**Please do not** create a public GitHub issue.
 
-### Licensing
+## Licensing
 
-See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
-
-We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.
+See the [LICENSE](LICENSE) file for our project's licensing. We may
+ask you to confirm the licensing of your contribution. Larger
+contributions may require a
+[Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement).

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ In a world where infrastructure as code is becoming the standard, TECLI bridges 
 - [Common Workflows](#-common-workflows)
 - [Screenshots](#-screenshots)
 - [Contributing](#-contributing)
+- [History](#-history)
 - [References](#-references)
 - [License](#-license)
 
@@ -46,20 +47,32 @@ In a world where infrastructure as code is becoming the standard, TECLI bridges 
 
 Before installing TECLI, ensure you have:
 
-- A Terraform Cloud/Enterprise account
+- A Terraform Cloud or Terraform Enterprise account
 - Appropriate API tokens (user, team, or organization)
+- Go 1.25 or later (only required if building from source)
 
 For more detailed prerequisites, visit our [Pre-Requisites Wiki](https://github.com/awslabs/tecli/wiki/Pre-Requisites).
 
-### Installation Steps
+### Install a pre-built binary
 
 1. Download the latest [release](https://github.com/awslabs/tecli/releases) for your operating system and platform.
-2. Extract the binary to a location in your PATH.
+2. Extract the binary to a location in your `PATH`.
 3. Verify the installation:
 
 ```bash
 tecli version
 ```
+
+### Build from source
+
+```bash
+git clone https://github.com/awslabs/tecli.git
+cd tecli
+go build -o tecli ./...
+./tecli version
+```
+
+`go build` requires Go 1.25+. The Terraform Cloud/Enterprise client used internally is [hashicorp/go-tfe v1.108+](https://pkg.go.dev/github.com/hashicorp/go-tfe).
 
 For more detailed installation instructions, visit our [Installation Wiki](https://github.com/awslabs/tecli/wiki/Installation).
 
@@ -287,10 +300,25 @@ We welcome contributions to TECLI! Please read our [Contributing Guidelines](CON
 | Silva, Valter | valterh@amazon.com | AWS Professional Services - Cloud Architect |
 | Dhingra, Prashit | | AWS Professional Services - Cloud Architect |
 
+## 🕒 History
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the full release history.
+
+### Modernization 2026-06
+
+A toolchain modernization pass was completed in June 2026 (tracked in PR [#27](https://github.com/awslabs/tecli/pull/27) and follow-up PRs):
+
+- Bumped `go.mod` to **Go 1.25**.
+- Migrated `hashicorp/go-tfe` from `v0.15.0` to `v1.108.0`.
+- Refreshed all transitive dependencies (cobra, viper, logrus, testify, x/crypto, afero, go-slug, go-retryablehttp).
+- Audited and rewrote the docs (this README, [`CHANGELOG.md`](CHANGELOG.md), [`COMMANDS.md`](COMMANDS.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), and the new [`ARCHITECTURE.md`](ARCHITECTURE.md) and [`docs/RELEASING.md`](docs/RELEASING.md)).
+
+The wiki pages under <https://github.com/awslabs/tecli/wiki> were last refreshed before the modernization; some links there may describe older Go/go-tfe versions.
+
 ## 🔗 References
 
 - [Terraform Cloud](https://www.terraform.io/docs/cloud/index.html) - Terraform Cloud is an application that helps teams use Terraform together.
-- [Terraform Cloud/Enterprise Go Client](https://github.com/hashicorp/go-tfe) - The official Go API client for Terraform Cloud/Enterprise.
+- [Terraform Cloud/Enterprise Go Client](https://github.com/hashicorp/go-tfe) - The official Go API client for Terraform Cloud/Enterprise (v1.108+ as of the modernization).
 - [clencli](https://github.com/awslabs/clencli) - Cloud Engineer CLI
 - [terminalizer](https://github.com/faressoft/terminalizer) - Record your terminal and generate animated gif images or share a web player link terminalizer.com
 

--- a/TOP-COMMANDS.md
+++ b/TOP-COMMANDS.md
@@ -1,116 +1,191 @@
 # Top Commands
 
-All the following commands require [TEAM API TOKEN](https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html#team-api-tokens).
-You can run `tecli configure create` to configure TECLI options. Alternatively, you can export [environment varibles](https://github.com/awslabs/tecli/wiki/Environment-Variables).
+Hand-curated cheat sheet of the most common TECLI invocations. The
+full command surface lives in [`COMMANDS.md`](COMMANDS.md).
 
-To export environment variables:
+All examples assume you have a configured profile or the appropriate
+[`TFC_*` environment variables](https://github.com/awslabs/tecli/wiki/Environment-Variables)
+set. The relevant tokens depend on the operation; most workspace and
+run operations need a [team API token](https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html#team-api-tokens).
 
-```
-# on Linux:
-export TFC_ORGANIZATION_TOKEN=XXX
-export TFC_TEAM_TOKEN=XXX
+## One-time setup
 
-# on Windows (powershell):
-$Env:TFC_ORGANIZATION_TOKEN="XXX"
-$Env:TFC_TEAM_TOKEN="XXX"
-```
+Either run `tecli configure create` and follow the prompts, or export:
 
-To list all workspaces part of an organization:
+```bash
+# Linux / macOS
+export TFC_ORGANIZATION=your-org
+export TFC_USER_TOKEN=your-user-token
+export TFC_TEAM_TOKEN=your-team-token
+export TFC_ORGANIZATION_TOKEN=your-org-token
 
-```
-tecli workspace list -o=${TFC_ORGANIZATION} -p=${PROFILE}
-```
-
-To find a workspace by name (instead of listing all workspaces and look for its ID):
-
-```
-tecli workspace find-by-name --organization=${TFC_ORGANIZATION} --name=${TFC_WORKSPACE_NAME}
-```
-
-To create a workspace and allow destroy plans:
-
-```
-tecli workspace create --organization=${TFC_ORGANIZATION} --name=${TFC_WORKSPACE_NAME} --allow-destroy-plan=true
+# Windows (PowerShell)
+$Env:TFC_ORGANIZATION="your-org"
+$Env:TFC_USER_TOKEN="your-user-token"
+$Env:TFC_TEAM_TOKEN="your-team-token"
+$Env:TFC_ORGANIZATION_TOKEN="your-org-token"
 ```
 
-To create a plan (if you want to upload your code to Terraform Cloud):
+## Workspace cookbook
 
-```
-tecli configuration-version create --workspace-id=${WORKSPACE_ID}
-tecli configuration-version upload --url=${CV_UPLOAD_URL} --path=./
-tecli run create --workspace-id=${WORKSPACE_ID} --comment="${COMMENT}"
-```
+List all workspaces in an organization:
 
-To check the staus of a run:
-
-```
-tecli run read --id=${RUN_ID}
+```bash
+tecli workspace list -o "${TFC_ORGANIZATION}" -p "${PROFILE}"
 ```
 
-You combine some `BASH` scripting and check if your plan has finished:
+Find a workspace by name (avoids paging through `list`):
 
-```
-while true; do STATUS=$(tecli run read --id=${RUN_ID} | jq -r ".Status"); if [ "${STATUS}" != "pending" ]; then break; else echo "RUN STATUS:${STATUS}, IF 'pending' TRY DISCARD PREVIOUS PLANS. SLEEP 5 seconds" && sleep 5; fi; done
-```
-
-To display the logs of a plan:
-
-```
-tecli plan logs --id=${PLAN_ID}
+```bash
+tecli workspace find-by-name \
+  --organization="${TFC_ORGANIZATION}" \
+  --name="${TFC_WORKSPACE_NAME}"
 ```
 
-To leave a comment on a plan:
+Create a workspace and allow destroy plans:
 
-```
-tecli run create --workspace-id=${WORKSPACE_ID} --comment="${COMMENT}" --is-destroy=true
-```
-
-To discard a run:
-
-```
-tecli run discard --id=${RUN_ID}
+```bash
+tecli workspace create \
+  --organization="${TFC_ORGANIZATION}" \
+  --name="${TFC_WORKSPACE_NAME}" \
+  --allow-destroy-plan=true
 ```
 
-To discard all runs:
+Lock / unlock a workspace:
 
-```
-tecli run discard-all --workspace-id=${WORKSPACE_ID}
-```
-
-To apply a plan:
-
-```
-tecli run apply --id=${RUN_ID} --comment="${COMMENT}"
+```bash
+tecli workspace lock   --id="${WORKSPACE_ID}"
+tecli workspace unlock --id="${WORKSPACE_ID}"
 ```
 
-To display the apply logs:
+## Run cookbook
 
-```
-tecli apply logs --id=${APPLY_ID}
-```
+Upload a configuration and create a run:
 
-To create a sensitive terraform variable:
-
-```
-tecli variable update --key=${VARIABLE_KEY} --value=${VARIABLE_VALUE} --workspace-id=${WORKSPACE_ID} --category=terraform --sensitive=true
+```bash
+tecli configuration-version create --workspace-id="${WORKSPACE_ID}"
+tecli configuration-version upload  --url="${CV_UPLOAD_URL}" --path=./
+tecli run create --workspace-id="${WORKSPACE_ID}" --comment="${COMMENT}"
 ```
 
-To create a sensitive environment variable:
+Check run status:
 
-```
-tecli variable create --key=${VARIABLE_KEY} --value=${VARIABLE_VALUE} --workspace-id=${WORKSPACE_ID} --category=env --sensitive=true
-
-# AWS CLI ENVIRONMENT VARIABLES
-tecli variable create --key=AWS_ACCESS_KEY_ID --value=${AWS_ACCESS_KEY_ID} --workspace-id=${WORKSPACE_ID} --category=env --sensitive=true
-tecli variable create --key=AWS_SECRET_ACCESS_KEY --value=${AWS_SECRET_ACCESS_KEY} --workspace-id=${WORKSPACE_ID} --category=env --sensitive=true
-tecli variable create --key=AWS_DEFAULT_REGION --value=${AWS_DEFAULT_REGION} --workspace-id=${WORKSPACE_ID} --category=env --sensitive=true
-
-## IF YOU ALSO NEED TO EXPORT AWS_SESSION_TOKEN:
-tecli variable create --key=AWS_SESSION_TOKEN --value=${AWS_SESSION_TOKEN} --workspace-id=${WORKSPACE_ID} --category=env --sensitive=true
+```bash
+tecli run read --id="${RUN_ID}"
 ```
 
-To delete all variables (be careful):
+Poll until the run finishes (bash one-liner):
 
+```bash
+while true; do
+  STATUS=$(tecli run read --id="${RUN_ID}" | jq -r ".Status")
+  if [ "${STATUS}" != "pending" ]; then
+    break
+  else
+    echo "RUN STATUS: ${STATUS} — sleeping 5s"
+    sleep 5
+  fi
+done
 ```
-tecli variable delete-all --workspace-id=${WORKSPACE_ID}
+
+Show plan logs:
+
+```bash
+tecli plan logs --id="${PLAN_ID}"
+```
+
+Create a destroy run:
+
+```bash
+tecli run create \
+  --workspace-id="${WORKSPACE_ID}" \
+  --comment="${COMMENT}" \
+  --is-destroy=true
+```
+
+Discard a single run, or discard everything queued on a workspace:
+
+```bash
+tecli run discard     --id="${RUN_ID}"
+tecli run discard-all --workspace-id="${WORKSPACE_ID}"
+```
+
+Apply a run and stream the apply logs:
+
+```bash
+tecli run apply --id="${RUN_ID}" --comment="${COMMENT}"
+tecli apply logs --id="${APPLY_ID}"
+```
+
+## Variable cookbook
+
+Create a sensitive Terraform variable:
+
+```bash
+tecli variable create \
+  --key="${VARIABLE_KEY}" \
+  --value="${VARIABLE_VALUE}" \
+  --workspace-id="${WORKSPACE_ID}" \
+  --category=terraform \
+  --sensitive=true
+```
+
+Create a sensitive environment variable:
+
+```bash
+tecli variable create \
+  --key="${VARIABLE_KEY}" \
+  --value="${VARIABLE_VALUE}" \
+  --workspace-id="${WORKSPACE_ID}" \
+  --category=env \
+  --sensitive=true
+```
+
+Bulk-load AWS credentials as env-category variables:
+
+```bash
+tecli variable create --key=AWS_ACCESS_KEY_ID     --value="${AWS_ACCESS_KEY_ID}"     --workspace-id="${WORKSPACE_ID}" --category=env --sensitive=true
+tecli variable create --key=AWS_SECRET_ACCESS_KEY --value="${AWS_SECRET_ACCESS_KEY}" --workspace-id="${WORKSPACE_ID}" --category=env --sensitive=true
+tecli variable create --key=AWS_DEFAULT_REGION    --value="${AWS_DEFAULT_REGION}"    --workspace-id="${WORKSPACE_ID}" --category=env --sensitive=true
+
+# If you also need a session token:
+tecli variable create --key=AWS_SESSION_TOKEN --value="${AWS_SESSION_TOKEN}" --workspace-id="${WORKSPACE_ID}" --category=env --sensitive=true
+```
+
+Update an existing variable by its key (instead of by ID):
+
+```bash
+tecli variable update-by-key \
+  --key="${VARIABLE_KEY}" \
+  --value="${VARIABLE_VALUE}" \
+  --workspace-id="${WORKSPACE_ID}"
+```
+
+Wipe every variable on a workspace (irreversible):
+
+```bash
+tecli variable delete-all --workspace-id="${WORKSPACE_ID}"
+```
+
+## VCS / OAuth cookbook
+
+List OAuth tokens (used to wire workspaces to a VCS repo):
+
+```bash
+tecli o-auth-token list --organization="${TFC_ORGANIZATION}"
+```
+
+Update an OAuth token's private SSH key (heredoc-friendly):
+
+```bash
+private_ssh_key="$(cat ~/.ssh/id_rsa)"
+tecli o-auth-token update --id="${OAUTH_TOKEN_ID}" --private-ssh-key "${private_ssh_key}"
+```
+
+Manage the OAuth client itself:
+
+```bash
+tecli o-auth-client list   --organization="${TFC_ORGANIZATION}"
+tecli o-auth-client read   --id="${OAUTH_CLIENT_ID}"
+tecli o-auth-client delete --id="${OAUTH_CLIENT_ID}"
 ```

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,89 @@
+# Releasing TECLI
+
+This is the cookbook for cutting a new TECLI release. The repository
+ships **two release-related GitHub Actions** plus a manual fallback:
+
+| Workflow                                          | Trigger             | Purpose                                         |
+| ------------------------------------------------- | ------------------- | ----------------------------------------------- |
+| `.github/workflows/release.yml` (release-please)  | Push to `main`      | Opens/updates a release PR; tags on merge.      |
+| `.github/workflows/publish.yml` (publish)         | Tag push (`v*`)     | Builds cross-platform binaries and a GH Release |
+| `.github/workflows/build.yml`                     | Every push          | Smoke-build only; no release output.            |
+
+## Standard release (release-please)
+
+`release-please` watches Conventional Commits (`feat:`, `fix:`,
+`chore:`...) on `main` and maintains a release PR titled something like
+`chore(main): release tecli x.y.z`.
+
+1. Land your work into `main` using Conventional Commits. The release
+   PR is updated automatically.
+2. Review the release PR — it bumps `box/resources/VERSION` and
+   regenerates `CHANGELOG.md`. Edit the PR body if you want to override
+   the auto-generated changelog.
+3. Merge the release PR. release-please pushes a tag `vX.Y.Z` and
+   creates a GitHub Release.
+4. The tag push fires `publish.yml`, which compiles binaries for the
+   matrix in [`Makefile`](../Makefile) (`tecli/compile` target) and
+   uploads them to the GitHub Release as draft prereleases.
+5. Confirm the binaries on the Releases page, untick **Draft** /
+   **Pre-release** as appropriate, and publish.
+
+### Conventional Commit cheatsheet
+
+| Commit prefix     | Bumps          |
+| ----------------- | -------------- |
+| `feat: ...`       | minor          |
+| `fix: ...`        | patch          |
+| `feat!: ...` or `BREAKING CHANGE:` in trailer | major |
+| `chore:`, `docs:`, `refactor:`, `test:`       | no bump        |
+
+## Manual release fallback
+
+If release-please is broken or you need an emergency tag:
+
+```bash
+# 1. Bump the embedded version
+echo "0.5.0-alpha" > box/resources/VERSION
+git add box/resources/VERSION
+git commit -m "chore: release v0.5.0-alpha"
+
+# 2. Update CHANGELOG.md by hand (Keep a Changelog format).
+$EDITOR CHANGELOG.md
+git add CHANGELOG.md
+git commit -m "docs: changelog for v0.5.0-alpha"
+
+# 3. Tag and push
+git tag v0.5.0-alpha
+git push origin main
+git push origin v0.5.0-alpha
+```
+
+The tag push triggers `publish.yml`, which produces binaries and a
+draft GitHub Release. From there:
+
+```bash
+# Optional: build binaries locally to double-check
+make tecli/compile
+ls dist/
+```
+
+Promote the GitHub Release from draft to published once the binaries
+are verified.
+
+## Versioning policy
+
+- `0.x-alpha` while breaking changes are still expected.
+- Promote to `0.x` once the public command surface is stable.
+- Promote to `1.0.0` when SemVer guarantees can be made on the CLI's
+  command names and flags.
+
+## Pre-release checklist
+
+- [ ] `go build ./...` passes locally on Go 1.25+.
+- [ ] `go vet ./...` returns no new warnings.
+- [ ] `make tecli/compile` succeeds (or rely on `publish.yml`).
+- [ ] `CHANGELOG.md` lists the user-facing changes since the previous
+      tag.
+- [ ] `box/resources/VERSION` matches the new tag.
+- [ ] `README.md`'s "Modernization" / install-version notes are
+      consistent with the new toolchain.


### PR DESCRIPTION
## Summary

Comprehensive docs sweep that lands alongside the `chore/modernize-toolchain` work in PR #27. This PR audits every Markdown file at the repo root, fixes drift against the actual command surface, and adds two missing top-level docs.

The audit was driven from the canonical source — the `*ValidArgs` slices and `helper.GetManual(...)` calls in `cobra/controller/` — so this should be a faithful, hand-checked snapshot of what `tecli --help` will actually print after the modernization.

## Files changed

| File | Change | Why |
| --- | --- | --- |
| `README.md` | Refresh install/build sections; add History pointing at PR #27 and the June 2026 modernization. | Previous rewrite (62ccd86) was good but predated the Go 1.25 / go-tfe v1.108 migration. |
| `CHANGELOG.md` | Replace 279-byte stub with full Keep-a-Changelog file. | The old file had two un-versioned "Bugfix"/"Feature" sections from years ago. New file enumerates the modernization changes and a summary of historical commits. |
| `COMMANDS.md` | List every subcommand under each top-level command (sourced from `*ValidArgs`). | Old file only showed top-level commands and didn't note that the canonical list lives in `cobra/controller/`. |
| `TOP-COMMANDS.md` | Reorganize into Workspace / Run / Variable / VCS cookbooks; fix `variable update --key=...` divergence (real command is `variable update-by-key`). | Smaller divergences against actual command names had crept in. |
| `CONTRIBUTING.md` | Update for Go 1.25 toolchain; add "How to run tests locally" (unit vs. integration with TFE creds); add "Branch strategy" section documenting `chore/modernize-toolchain`. | Old file assumed Go ~1.15 era and said to work against `master`. |
| `ARCHITECTURE.md` | **New.** One-page tour of `cobra/cmd/` (thin adapters) → `cobra/controller/` (business logic + go-tfe) → `cobra/aid/` (option builders / file I/O) → `helper/`, plus `box/`, `clencli/`, `habits/`, `examples/`, `tests/`. Includes a "how to add a new command" checklist. | Repo had no top-level architecture doc; new contributors had to grep their way in. |
| `docs/RELEASING.md` | **New.** Document the release-please flow on `main`, the `publish.yml` tag-driven build, and a manual fallback. Includes a Conventional Commit cheatsheet and a pre-release checklist. | Release process was tribal knowledge. |

## What I didn't touch

- Inclusive-language fixes (deferred to the dedicated agent in this modernization phase).
- The `wiki/` pages on github.com/awslabs/tecli/wiki — flagged in the README's History section as potentially stale, but kept out of scope.
- `go.mod` / `go.sum` — owned by the foundation PR.

## Test plan

- [x] `go build ./...` passes.
- [x] `go vet ./...` produces only the pre-existing `tests/cmd_workspace_test.go:42 undefined: executeCommand` warning (not introduced by this PR; tracked separately).
- [x] Every command name mentioned in `COMMANDS.md` and `TOP-COMMANDS.md` cross-checked against the `*ValidArgs` definitions in `cobra/controller/`.
- [x] All internal Markdown links (`README.md` ↔ `CHANGELOG.md` ↔ `ARCHITECTURE.md` ↔ `docs/RELEASING.md` ↔ `CONTRIBUTING.md` ↔ `COMMANDS.md`/`TOP-COMMANDS.md`) traced manually.
- [ ] Reviewer to confirm the wiki links in `README.md` still resolve (left as a manual check; agent did not crawl github.com/awslabs/tecli/wiki).