### PR TITLE
refactor: idiomatic error handling — drop Fatal calls, use %w wrapping

### DIFF
--- a/cobra/aid/configure.go
+++ b/cobra/aid/configure.go
@@ -53,6 +53,11 @@ func SetConfigureFlags(cmd *cobra.Command) {
 }
 
 // GetCredentialProfileFlags TODO ...
+//
+// The Fatalf calls in this function fire only when a cobra flag is not
+// registered, which is a compile-time / wiring bug rather than a runtime
+// error. Returning a zero-valued profile would silently mask such bugs and
+// produce confusing downstream failures, so we keep Fatalf here.
 func GetCredentialProfileFlags(cmd *cobra.Command) model.CredentialProfile {
 	var cp model.CredentialProfile
 

--- a/cobra/aid/configure.go
+++ b/cobra/aid/configure.go
@@ -155,11 +155,11 @@ func CheckAppDirAndFile() error {
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			// Config file not found
-			return fmt.Errorf("configuration file not found\n%v", err)
+			return fmt.Errorf("configuration file not found\n%w", err)
 		}
 
 		// Config file was found but another error was produced
-		return fmt.Errorf("unable to read config file\n%v", err)
+		return fmt.Errorf("unable to read config file\n%w", err)
 	}
 
 	return nil
@@ -280,7 +280,7 @@ func HasCreatedAppDir(cmd *cobra.Command) (bool, error) {
 				// necessary to create an empty file for Viper
 				f, err := os.Create(GetAppInfo().CredentialsFilePath)
 				if err != nil {
-					return false, fmt.Errorf("unable to create empty credentials file\n%v", err)
+					return false, fmt.Errorf("unable to create empty credentials file\n%w", err)
 				}
 				f.Close()
 

--- a/cobra/aid/root.go
+++ b/cobra/aid/root.go
@@ -71,7 +71,7 @@ func SetupLoggingOutput(path string) error {
 
 	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("unable to open log file\n%v", err)
+		return fmt.Errorf("unable to open log file\n%w", err)
 	}
 
 	logrus.SetFormatter(&logrus.JSONFormatter{})
@@ -108,7 +108,7 @@ func LoadViper() {
 func SetupLoggingLevel(level string) error {
 	lvl, err := logrus.ParseLevel(level)
 	if err != nil {
-		return fmt.Errorf("unable to set log level\n%v", err)
+		return fmt.Errorf("unable to set log level\n%w", err)
 	}
 
 	logrus.SetLevel(lvl)

--- a/cobra/aid/root.go
+++ b/cobra/aid/root.go
@@ -31,6 +31,8 @@ func GetAppInfo() model.App {
 
 	configDir, err := os.UserConfigDir()
 	if err != nil {
+		// Fatal here is acceptable: without the user config directory we
+		// cannot locate credentials or logs and there is no recovery path.
 		logrus.Fatalf("unable to read user configuration directory\n%v", err)
 	}
 
@@ -51,6 +53,8 @@ func GetAppInfo() model.App {
 
 	app.WorkingDir, err = os.Getwd()
 	if err != nil {
+		// Exit here is acceptable: without a working directory, none of the
+		// downstream config/file operations can resolve relative paths.
 		fmt.Printf("Unable to detect the current directory\n%v", err)
 		os.Exit(1)
 	}
@@ -130,7 +134,9 @@ func getTFENewClient(config *tfe.Config) (*tfe.Client, error) {
 	return client, err
 }
 
-// GetTFEClient returns a new terraform api client given a token
+// GetTFEClient returns a new terraform api client given a token.
+// Fatal here is acceptable: without a working TFE client every command in
+// this CLI is a no-op, and there is no useful recovery path.
 func GetTFEClient(token string) *tfe.Client {
 	config := getTFEConfig(token)
 	client, err := getTFENewClient(config)

--- a/cobra/controller/apply.go
+++ b/cobra/controller/apply.go
@@ -82,19 +82,19 @@ func applyRun(cmd *cobra.Command, args []string) error {
 	case "read":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		apply, err := applyRead(client, id)
 		if err == nil {
 			fmt.Println(aid.ToJSON(apply))
 		} else {
-			return fmt.Errorf("apply %s not found\n%v", id, err)
+			return fmt.Errorf("apply %s not found\n%w", id, err)
 		}
 	case "logs":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		logs, err := applyLogs(client, id)

--- a/cobra/controller/apply.go
+++ b/cobra/controller/apply.go
@@ -26,7 +26,6 @@ import (
 	"github.com/awslabs/tecli/cobra/dao"
 	"github.com/awslabs/tecli/helper"
 	"github.com/hashicorp/go-tfe"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -100,7 +99,7 @@ func applyRun(cmd *cobra.Command, args []string) error {
 
 		logs, err := applyLogs(client, id)
 		if err != nil {
-			logrus.Fatalf("unable to read apply logs\n%v", err)
+			return fmt.Errorf("unable to read apply logs\n%w", err)
 		}
 		fmt.Println(StreamToString(logs))
 	}

--- a/cobra/controller/configurationVersion.go
+++ b/cobra/controller/configurationVersion.go
@@ -96,7 +96,7 @@ func configurationVersionRun(cmd *cobra.Command, args []string) error {
 	case "list":
 		workspaceID, err := cmd.Flags().GetString("workspace-id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag workspace-id\n%v", err)
+			return fmt.Errorf("unable to get flag workspace-id\n%w", err)
 		}
 
 		list, err := configurationVersionList(client, workspaceID, tfe.ConfigurationVersionListOptions{})
@@ -109,7 +109,7 @@ func configurationVersionRun(cmd *cobra.Command, args []string) error {
 	case "create":
 		workspaceID, err := cmd.Flags().GetString("workspace-id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag workspace-id\n%v", err)
+			return fmt.Errorf("unable to get flag workspace-id\n%w", err)
 		}
 
 		options := aid.GetConfigurationVersionCreateOptions(cmd)
@@ -118,37 +118,37 @@ func configurationVersionRun(cmd *cobra.Command, args []string) error {
 		if err == nil && cv.ID != "" {
 			fmt.Println(aid.ToJSON(cv))
 		} else {
-			return fmt.Errorf("unable to create configuration version\n%v", err)
+			return fmt.Errorf("unable to create configuration version\n%w", err)
 		}
 	case "read":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		cv, err := configurationVersionRead(client, id)
 		if err == nil {
 			fmt.Println(aid.ToJSON(cv))
 		} else {
-			return fmt.Errorf("configuration version %s not found\n%v", id, err)
+			return fmt.Errorf("configuration version %s not found\n%w", id, err)
 		}
 
 	case "upload":
 		url, err := cmd.Flags().GetString("url")
 		if err != nil {
-			return fmt.Errorf("unable to get flag url\n%v", err)
+			return fmt.Errorf("unable to get flag url\n%w", err)
 		}
 
 		path, err := cmd.Flags().GetString("path")
 		if err != nil {
-			return fmt.Errorf("unable to get flag path\n%v", err)
+			return fmt.Errorf("unable to get flag path\n%w", err)
 		}
 
 		err = configurationVersionUpload(client, url, path)
 		if err == nil {
 			fmt.Println("upload completed successfully")
 		} else {
-			return fmt.Errorf("unable to upload to configuration version\n%v", err)
+			return fmt.Errorf("unable to upload to configuration version\n%w", err)
 		}
 	}
 

--- a/cobra/controller/configure.go
+++ b/cobra/controller/configure.go
@@ -74,7 +74,7 @@ func configurePreRun(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("mode") {
 		mode, err := cmd.Flags().GetString("mode")
 		if err != nil {
-			return fmt.Errorf("unable to get flag mode\n%v", err)
+			return fmt.Errorf("unable to get flag mode\n%w", err)
 		}
 
 		if mode != "interactive" && mode != "non-interactive" {
@@ -88,7 +88,7 @@ func configurePreRun(cmd *cobra.Command, args []string) error {
 func configureRun(cmd *cobra.Command, args []string) error {
 	mode, err := cmd.Flags().GetString("mode")
 	if err != nil {
-		return fmt.Errorf("unable to get flag mode\n%v", err)
+		return fmt.Errorf("unable to get flag mode\n%w", err)
 	}
 
 	fArg := args[0]
@@ -103,7 +103,7 @@ func configureRun(cmd *cobra.Command, args []string) error {
 	case "create":
 		err = configureCreateCredentials(cmd, mode)
 		if err != nil {
-			return fmt.Errorf("unable to create profile\n%v", err)
+			return fmt.Errorf("unable to create profile\n%w", err)
 		}
 		cmd.Printf("profile %s created successfully\n", profile)
 
@@ -117,14 +117,14 @@ func configureRun(cmd *cobra.Command, args []string) error {
 	case "update":
 		err = configureUpdateCredentials(cmd, mode)
 		if err != nil {
-			return fmt.Errorf("unable to update profile\n%v", err)
+			return fmt.Errorf("unable to update profile\n%w", err)
 		}
 		cmd.Printf("profile %s updated successfully\n", profile)
 
 	case "delete":
 		err := configureDeleteCredential()
 		if err != nil {
-			return fmt.Errorf("unable to delete profile\n%v", err)
+			return fmt.Errorf("unable to delete profile\n%w", err)
 		}
 		cmd.Printf("profile %s deleted successfully\n", profile)
 

--- a/cobra/controller/oAuthClient.go
+++ b/cobra/controller/oAuthClient.go
@@ -116,31 +116,31 @@ func oAuthClientRun(cmd *cobra.Command, args []string) error {
 		if err == nil && oAuthClient.ID != "" {
 			fmt.Println(aid.ToJSON(oAuthClient))
 		} else {
-			return fmt.Errorf("unable to create o-auth-client\n%v", err)
+			return fmt.Errorf("unable to create o-auth-client\n%w", err)
 		}
 	case "read":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		oAuthClient, err := oAuthClientRead(client, id)
 		if err == nil {
 			fmt.Println(aid.ToJSON(oAuthClient))
 		} else {
-			return fmt.Errorf("o-auth-client %s not found\n%v", id, err)
+			return fmt.Errorf("o-auth-client %s not found\n%w", id, err)
 		}
 	case "delete":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		err = oAuthClientDelete(client, id)
 		if err == nil {
 			fmt.Printf("o-auth-client %s deleted successfully\n", id)
 		} else {
-			return fmt.Errorf("unable to delete o-auth-client %s\n%v", id, err)
+			return fmt.Errorf("unable to delete o-auth-client %s\n%w", id, err)
 		}
 	}
 

--- a/cobra/controller/oAuthToken.go
+++ b/cobra/controller/oAuthToken.go
@@ -93,19 +93,19 @@ func oAuthTokenRun(cmd *cobra.Command, args []string) error {
 	case "read":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		oAuthToken, err := oAuthTokenRead(client, id)
 		if err == nil {
 			fmt.Println(aid.ToJSON(oAuthToken))
 		} else {
-			return fmt.Errorf("o-auth-token %s not found\n%v", id, err)
+			return fmt.Errorf("o-auth-token %s not found\n%w", id, err)
 		}
 	case "update":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		options := aid.GetOAuthTokenUpdateOptions(cmd)
@@ -114,19 +114,19 @@ func oAuthTokenRun(cmd *cobra.Command, args []string) error {
 		if err == nil && oAuthToken.ID != "" {
 			fmt.Println(aid.ToJSON(oAuthToken))
 		} else {
-			return fmt.Errorf("unable to create o-auth-token\n%v", err)
+			return fmt.Errorf("unable to create o-auth-token\n%w", err)
 		}
 	case "delete":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		err = oAuthTokenDelete(client, id)
 		if err == nil {
 			fmt.Printf("o-auth-token %s deleted successfully\n", id)
 		} else {
-			return fmt.Errorf("unable to delete o-auth-token %s\n%v", id, err)
+			return fmt.Errorf("unable to delete o-auth-token %s\n%w", id, err)
 		}
 	}
 

--- a/cobra/controller/plan.go
+++ b/cobra/controller/plan.go
@@ -82,19 +82,19 @@ func planRun(cmd *cobra.Command, args []string) error {
 	case "read":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		plan, err := planRead(client, id)
 		if err == nil {
 			fmt.Println(aid.ToJSON(plan))
 		} else {
-			return fmt.Errorf("plan %s not found\n%v", id, err)
+			return fmt.Errorf("plan %s not found\n%w", id, err)
 		}
 	case "logs":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		logs, err := planLogs(client, id)

--- a/cobra/controller/plan.go
+++ b/cobra/controller/plan.go
@@ -26,7 +26,6 @@ import (
 	"github.com/awslabs/tecli/cobra/dao"
 	"github.com/awslabs/tecli/helper"
 	"github.com/hashicorp/go-tfe"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -100,7 +99,7 @@ func planRun(cmd *cobra.Command, args []string) error {
 
 		logs, err := planLogs(client, id)
 		if err != nil {
-			logrus.Fatalf("unable to read plan logs\n%v", err)
+			return fmt.Errorf("unable to read plan logs\n%w", err)
 		}
 		fmt.Println(StreamToString(logs))
 	}

--- a/cobra/controller/run.go
+++ b/cobra/controller/run.go
@@ -92,7 +92,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 	case "list":
 		workspaceID, err := cmd.Flags().GetString("workspace-id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag workspace-id\n%v", err)
+			return fmt.Errorf("unable to get flag workspace-id\n%w", err)
 		}
 
 		list, err := runList(client, workspaceID, tfe.RunListOptions{})
@@ -107,26 +107,26 @@ func runRun(cmd *cobra.Command, args []string) error {
 
 		workspaceID, err := cmd.Flags().GetString("workspace-id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag workspace-id\n%v", err)
+			return fmt.Errorf("unable to get flag workspace-id\n%w", err)
 		}
 
 		if workspaceID != "" {
 			workspace, err := workspaceReadByID(client, workspaceID)
 			if err != nil {
-				return fmt.Errorf("unable to find workspace %s\n%v", workspaceID, err)
+				return fmt.Errorf("unable to find workspace %s\n%w", workspaceID, err)
 			}
 			options.Workspace = workspace
 		}
 
 		cvID, err := cmd.Flags().GetString("configuration-version-id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag configuration-version-id\n%v", err)
+			return fmt.Errorf("unable to get flag configuration-version-id\n%w", err)
 		}
 
 		if cvID != "" {
 			cv, err := configurationVersionRead(client, cvID)
 			if err != nil {
-				return fmt.Errorf("unable to find configuration version %s\n%v", cvID, err)
+				return fmt.Errorf("unable to find configuration version %s\n%w", cvID, err)
 			}
 
 			if cv.ID != "" {
@@ -139,25 +139,25 @@ func runRun(cmd *cobra.Command, args []string) error {
 		if err == nil && run.ID != "" {
 			fmt.Println(aid.ToJSON(run))
 		} else {
-			return fmt.Errorf("unable to create run\n%v", err)
+			return fmt.Errorf("unable to create run\n%w", err)
 		}
 
 	case "read":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		run, err := runRead(client, id)
 		if err == nil {
 			fmt.Println(aid.ToJSON(run))
 		} else {
-			return fmt.Errorf("run %s not found\n%v", id, err)
+			return fmt.Errorf("run %s not found\n%w", id, err)
 		}
 	case "read-with-options":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		options := aid.GetRunReadOptions(cmd)
@@ -165,38 +165,38 @@ func runRun(cmd *cobra.Command, args []string) error {
 		if err == nil {
 			fmt.Println(aid.ToJSON(run))
 		} else {
-			return fmt.Errorf("run %s not found\n%v", id, err)
+			return fmt.Errorf("run %s not found\n%w", id, err)
 		}
 	case "apply":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		options := aid.GetRunApplyOptions(cmd)
 		err = runApply(client, id, options)
 		if err != nil {
-			return fmt.Errorf("unable to apply run\n%v", err)
+			return fmt.Errorf("unable to apply run\n%w", err)
 		}
 
 		fmt.Println("run applied successfully")
 	case "cancel":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		options := aid.GetRunCancelOptions(cmd)
 		err = runCancel(client, id, options)
 		if err != nil {
-			return fmt.Errorf("unable to cancel run\n%v", err)
+			return fmt.Errorf("unable to cancel run\n%w", err)
 		}
 
 		fmt.Println("run cancelled successfully")
 	case "cancel-all":
 		workspaceID, err := cmd.Flags().GetString("workspace-id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag workspace-id\n%v", err)
+			return fmt.Errorf("unable to get flag workspace-id\n%w", err)
 		}
 
 		list, err := runList(client, workspaceID, tfe.RunListOptions{})
@@ -220,20 +220,20 @@ func runRun(cmd *cobra.Command, args []string) error {
 	case "force-cancel":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		options := aid.GetRunForceCancelOptions(cmd)
 		err = runForceCancel(client, id, options)
 		if err != nil {
-			return fmt.Errorf("unable to force ancel run\n%v", err)
+			return fmt.Errorf("unable to force ancel run\n%w", err)
 		}
 
 		fmt.Println("run cancelled successfully")
 	case "force-cancel-all":
 		workspaceID, err := cmd.Flags().GetString("workspace-id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag workspace-id\n%v", err)
+			return fmt.Errorf("unable to get flag workspace-id\n%w", err)
 		}
 
 		list, err := runList(client, workspaceID, tfe.RunListOptions{})
@@ -256,18 +256,18 @@ func runRun(cmd *cobra.Command, args []string) error {
 	case "discard":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		options := aid.GetRunDiscardOptions(cmd)
 		err = runDiscard(client, id, options)
 		if err != nil {
-			return fmt.Errorf("unable to discard run\n%v", err)
+			return fmt.Errorf("unable to discard run\n%w", err)
 		}
 	case "discard-all":
 		workspaceID, err := cmd.Flags().GetString("workspace-id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag workspace-id\n%v", err)
+			return fmt.Errorf("unable to get flag workspace-id\n%w", err)
 		}
 
 		list, err := runList(client, workspaceID, tfe.RunListOptions{})

--- a/cobra/controller/sshKey.go
+++ b/cobra/controller/sshKey.go
@@ -105,7 +105,7 @@ func sshKeyPreRun(cmd *cobra.Command, args []string) error {
 func sshKeyRun(cmd *cobra.Command, args []string) error {
 	// config, err := cmd.Flags().GetString("config")
 	// if err != nil {
-	// 	return fmt.Errorf("unable to get flag config\n%v", err)
+	// 	return fmt.Errorf("unable to get flag config\n%w", err)
 	// }
 
 	// aid.LoadViper(config)
@@ -142,20 +142,20 @@ func sshKeyRun(cmd *cobra.Command, args []string) error {
 	case "read":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		sshKey, err := sshKeyRead(client, id)
 		if err == nil {
 			fmt.Println(aid.ToJSON(sshKey))
 		} else {
-			return fmt.Errorf("ssh key %s not found\n%v", id, err)
+			return fmt.Errorf("ssh key %s not found\n%w", id, err)
 		}
 
 	case "update":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		options := aid.GetSSHKeysUpdateOptions(cmd)
@@ -163,19 +163,19 @@ func sshKeyRun(cmd *cobra.Command, args []string) error {
 		if err == nil && sshKey.ID != "" {
 			fmt.Println(aid.ToJSON(sshKey))
 		} else {
-			return fmt.Errorf("unable to update ssh key\n%v", err)
+			return fmt.Errorf("unable to update ssh key\n%w", err)
 		}
 	case "delete":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		err = sshKeyDelete(client, id)
 		if err == nil {
 			cmd.Printf("ssh key %s deleted successfully\n", id)
 		} else {
-			return fmt.Errorf("unable to delete ssh key %s\n%v", id, err)
+			return fmt.Errorf("unable to delete ssh key %s\n%w", id, err)
 		}
 	}
 

--- a/cobra/controller/variable.go
+++ b/cobra/controller/variable.go
@@ -67,7 +67,7 @@ func variablePreRun(cmd *cobra.Command, args []string) error {
 	logrus.Tracef("start: variablePreRun")
 
 	if err := helper.ValidateCmdArgsV2(cmd, args); err != nil {
-		return fmt.Errorf("unexpected error\n%v", err)
+		return fmt.Errorf("unexpected error\n%w", err)
 	}
 
 	switch args[0] {
@@ -126,7 +126,7 @@ func variableRun(cmd *cobra.Command, args []string) error {
 		if err == nil && variable.ID != "" {
 			fmt.Println(aid.ToJSON(variable))
 		} else {
-			return fmt.Errorf("unable to create variable\n%v", err)
+			return fmt.Errorf("unable to create variable\n%w", err)
 		}
 
 	case "read":
@@ -137,7 +137,7 @@ func variableRun(cmd *cobra.Command, args []string) error {
 		if err == nil {
 			fmt.Println(aid.ToJSON(variable))
 		} else {
-			return fmt.Errorf("variable %s not found\n%v", id, err)
+			return fmt.Errorf("variable %s not found\n%w", id, err)
 		}
 
 	case "update":
@@ -149,7 +149,7 @@ func variableRun(cmd *cobra.Command, args []string) error {
 		if err == nil && variable.ID != "" {
 			fmt.Println(aid.ToJSON(variable))
 		} else {
-			return fmt.Errorf("unable to update variable\n%v", err)
+			return fmt.Errorf("unable to update variable\n%w", err)
 		}
 
 	case "update-by-key":
@@ -171,7 +171,7 @@ func variableRun(cmd *cobra.Command, args []string) error {
 		if err == nil && variable.ID != "" {
 			fmt.Println(aid.ToJSON(variable))
 		} else {
-			return fmt.Errorf("unable to update variable\n%v", err)
+			return fmt.Errorf("unable to update variable\n%w", err)
 		}
 
 	case "delete":
@@ -182,21 +182,21 @@ func variableRun(cmd *cobra.Command, args []string) error {
 		if err == nil {
 			fmt.Printf("variable %s deleted successfully\n", id)
 		} else {
-			return fmt.Errorf("unable to delete variable %s\n%v", id, err)
+			return fmt.Errorf("unable to delete variable %s\n%w", id, err)
 		}
 
 	case "delete-all":
 		workspaceID := helper.GetCmdFlagString(cmd, "workspace-id")
 		list, err := variableList(client, workspaceID, tfe.VariableListOptions{})
 		if err != nil {
-			return fmt.Errorf("no variable was found\n%v", err)
+			return fmt.Errorf("no variable was found\n%w", err)
 		}
 
 		for _, v := range list.Items {
 			fmt.Printf("attempting to delete variable %s (%s)\n", v.Key, v.ID)
 			err := variableDelete(client, workspaceID, v.ID)
 			if err != nil {
-				return fmt.Errorf("unable to delete variable %s (%s)\n%v", v.Key, v.ID, err)
+				return fmt.Errorf("unable to delete variable %s (%s)\n%w", v.Key, v.ID, err)
 			}
 
 			fmt.Printf("variable %s (%s) deleted successfully\n", v.Key, v.ID)

--- a/cobra/controller/workspace.go
+++ b/cobra/controller/workspace.go
@@ -149,7 +149,7 @@ func workspaceRun(cmd *cobra.Command, args []string) error {
 		if err == nil && workspace.ID != "" {
 			fmt.Println(aid.ToJSON(workspace))
 		} else {
-			return fmt.Errorf("unable to create workspace\n%v", err)
+			return fmt.Errorf("unable to create workspace\n%w", err)
 		}
 	case "read":
 		name, err := cmd.Flags().GetString("name")
@@ -162,19 +162,19 @@ func workspaceRun(cmd *cobra.Command, args []string) error {
 		if err == nil {
 			fmt.Println(aid.ToJSON(workspace))
 		} else {
-			return fmt.Errorf("workspace %s not found\n%v", name, err)
+			return fmt.Errorf("workspace %s not found\n%w", name, err)
 		}
 	case "read-by-id":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		workspace, err := workspaceReadByID(client, id)
 		if err == nil {
 			fmt.Println(aid.ToJSON(workspace))
 		} else {
-			return fmt.Errorf("workspace %s not found\n%v", id, err)
+			return fmt.Errorf("workspace %s not found\n%w", id, err)
 		}
 	case "update":
 		name, err := cmd.Flags().GetString("name")
@@ -188,12 +188,12 @@ func workspaceRun(cmd *cobra.Command, args []string) error {
 		if err == nil && workspace.ID != "" {
 			fmt.Println(aid.ToJSON(workspace))
 		} else {
-			return fmt.Errorf("unable to update workspace\n%v", err)
+			return fmt.Errorf("unable to update workspace\n%w", err)
 		}
 	case "update-by-id":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		options := aid.GetWorkspaceUpdateOptions(cmd)
@@ -201,7 +201,7 @@ func workspaceRun(cmd *cobra.Command, args []string) error {
 		if err == nil && workspace.ID != "" {
 			fmt.Println(aid.ToJSON(workspace))
 		} else {
-			return fmt.Errorf("unable to update workspace\n%v", err)
+			return fmt.Errorf("unable to update workspace\n%w", err)
 		}
 	case "delete":
 		name, err := cmd.Flags().GetString("name")
@@ -214,19 +214,19 @@ func workspaceRun(cmd *cobra.Command, args []string) error {
 		if err == nil {
 			fmt.Printf("workspace %s deleted successfully\n", name)
 		} else {
-			return fmt.Errorf("unable to delete workspace %s\n%v", name, err)
+			return fmt.Errorf("unable to delete workspace %s\n%w", name, err)
 		}
 	case "delete-by-id":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		err = workspaceDeleteByID(client, id)
 		if err == nil {
 			fmt.Printf("workspace %s deleted successfully\n", id)
 		} else {
-			return fmt.Errorf("unable to delete workspace %s\n%v", id, err)
+			return fmt.Errorf("unable to delete workspace %s\n%w", id, err)
 		}
 	case "remove-vcs-connection":
 		name, err := cmd.Flags().GetString("name")
@@ -239,29 +239,29 @@ func workspaceRun(cmd *cobra.Command, args []string) error {
 		if err == nil {
 			fmt.Println(aid.ToJSON(workspace))
 		} else {
-			return fmt.Errorf("unable to remove vcs connection\n%v", err)
+			return fmt.Errorf("unable to remove vcs connection\n%w", err)
 		}
 	case "remove-vcs-connection-by-id":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		workspace, err := workspaceRemoveVCSConnectionByID(client, id)
 		if err == nil {
 			fmt.Println(aid.ToJSON(workspace))
 		} else {
-			return fmt.Errorf("unable to remove vcs connection\n%v", err)
+			return fmt.Errorf("unable to remove vcs connection\n%w", err)
 		}
 	case "lock":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		workspace, err := workspaceLock(client, id)
 		if err != nil {
-			return fmt.Errorf("unable to lock workspace\n%v", err)
+			return fmt.Errorf("unable to lock workspace\n%w", err)
 		}
 
 		if workspace.Locked {
@@ -270,7 +270,7 @@ func workspaceRun(cmd *cobra.Command, args []string) error {
 	case "unlock":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		workspace, err := workspaceUnlock(client, id)
@@ -284,7 +284,7 @@ func workspaceRun(cmd *cobra.Command, args []string) error {
 	case "force-unlock":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		workspace, err := workspaceForceUnlock(client, id)
@@ -298,7 +298,7 @@ func workspaceRun(cmd *cobra.Command, args []string) error {
 	case "assign-ssh-key":
 		id, err := cmd.Flags().GetString("id")
 		if err != nil {
-			return fmt.Errorf("unable to get flag id\n%v", err)
+			return fmt.Errorf("unable to get flag id\n%w", err)
 		}
 
 		options := aid.GetWorkspaceAssignSSHKeyOptions(cmd)

--- a/cobra/dao/configure.go
+++ b/cobra/dao/configure.go
@@ -33,12 +33,12 @@ func GetCredentials() (model.Credentials, error) {
 	var creds model.Credentials
 	err := viper.ReadInConfig()
 	if err != nil {
-		return creds, fmt.Errorf("unable to read credentials\n%v", err)
+		return creds, fmt.Errorf("unable to read credentials\n%w", err)
 	}
 
 	err = viper.Unmarshal(&creds)
 	if err != nil {
-		return creds, fmt.Errorf("unable to unmarshall credentials\n%v", err)
+		return creds, fmt.Errorf("unable to unmarshall credentials\n%w", err)
 	}
 
 	return creds, err

--- a/helper/cobra.go
+++ b/helper/cobra.go
@@ -58,7 +58,7 @@ func ValidateCmdArgsV2(cmd *cobra.Command, args []string) error {
 	err := cmd.ValidateArgs(args)
 	if err != nil {
 		logrus.Errorf("cobra unable to validate args")
-		return fmt.Errorf("invalid arguments\n%v", err)
+		return fmt.Errorf("invalid arguments\n%w", err)
 	}
 
 	if len(args) == 0 {
@@ -108,7 +108,7 @@ func ValidateCmdFlagString(cmd *cobra.Command, flag string) error {
 	logrus.Tracef("start: validate flag")
 	value, err := cmd.Flags().GetString(flag)
 	if err != nil {
-		return fmt.Errorf("unable to get flag %s\n%v", flag, err)
+		return fmt.Errorf("unable to get flag %s\n%w", flag, err)
 	}
 
 	if value == "" {

--- a/helper/files.go
+++ b/helper/files.go
@@ -58,7 +58,7 @@ func WriteInterfaceToFile(in interface{}, path string) error {
 
 	err = ioutil.WriteFile(path, b, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("unable to update:%s\n%v", path, err)
+		return fmt.Errorf("unable to update:%s\n%w", path, err)
 	}
 
 	return err
@@ -167,7 +167,7 @@ func FileSize(path string) (int64, error) {
 	if FileExists(path) {
 		info, err := os.Stat(path)
 		if err != nil {
-			return size, fmt.Errorf("unable to obtain information about file: %s\n%v", path, err)
+			return size, fmt.Errorf("unable to obtain information about file: %s\n%w", path, err)
 		}
 		size = info.Size()
 	} else {

--- a/helper/files.go
+++ b/helper/files.go
@@ -27,7 +27,7 @@ func WriteFile(filename string, data []byte) bool {
 	err := ioutil.WriteFile(filename, data, os.ModePerm)
 
 	if err != nil {
-		logrus.Fatal(err)
+		logrus.Errorf("unable to write file %s: %v", filename, err)
 		return false
 	}
 
@@ -167,10 +167,7 @@ func FileSize(path string) (int64, error) {
 	if FileExists(path) {
 		info, err := os.Stat(path)
 		if err != nil {
-			if err != nil {
-				return size, fmt.Errorf("unable to obtain information about file: %s\n%s", path, err)
-			}
-			return size, err
+			return size, fmt.Errorf("unable to obtain information about file: %s\n%v", path, err)
 		}
 		size = info.Size()
 	} else {
@@ -180,11 +177,13 @@ func FileSize(path string) (int64, error) {
 }
 
 // ListFiles list of all file names in the given directory. Pass "." if you want to list at the current directory.
+// Returns a nil slice if the directory cannot be read; the error is logged.
 func ListFiles(dir string) []os.FileInfo {
 	files, err := ioutil.ReadDir(dir)
 
 	if err != nil {
-		logrus.Fatal(err)
+		logrus.Errorf("unable to list files in %s: %v", dir, err)
+		return nil
 	}
 
 	return files

--- a/helper/manual.go
+++ b/helper/manual.go
@@ -25,7 +25,7 @@ func GetManual(command string, args []string) (Manual, error) {
 	if status {
 		err = yaml.Unmarshal(manualBlob, &man)
 		if err != nil {
-			return man, fmt.Errorf("unable to decode YAML file, error:\n%v", err)
+			return man, fmt.Errorf("unable to decode YAML file, error:\n%w", err)
 		}
 	} else {
 		logrus.Fatal("unable to read manual from box")


### PR DESCRIPTION
## Summary

Two related cleanups identified in the toolchain modernization assessment.

### 1. Drop `logrus.Fatal*` where a return is feasible
`Fatal`-class calls invoke `os.Exit(1)`, which:
- Bypasses any `defer`s (no cleanup, no log flush).
- Prevents unit tests from exercising the error path.
- Short-circuits cobra's own error formatting in `RunE` handlers.

Fixed call sites:
- `cobra/controller/plan.go:103` and `cobra/controller/apply.go:103` — these are inside `RunE` handlers, so the natural fix is to return a wrapped error and let cobra render it.
- `helper/files.go` `WriteFile` and `ListFiles` — replaced `logrus.Fatal` with `logrus.Errorf` + zero-value return. The exported function signatures (`bool`, `[]os.FileInfo`) are preserved so no caller changes were required.

For the truly non-recoverable cases (`GetAppInfo` with no user config dir / no working dir, `GetTFEClient` with no working API client, `GetCredentialProfileFlags` on cobra flag-not-registered which is a wiring bug, not a runtime error), the `Fatal`/`os.Exit` stays but a comment now explains why.

### 2. Use `%w` for error wrapping
Mechanical sweep over `fmt.Errorf("...: %v", err)` to `%w` so `errors.Is` / `errors.As` work against the wrapped chain. Non-error `%v` formatters (e.g. printing a `[]string` of valid args in `helper/cobra.go`) were intentionally left untouched. `%w` was *not* applied to `logrus.Fatalf`/`logrus.Errorf`/`fmt.Printf` — `%w` is only valid inside `fmt.Errorf`.

## Scope guardrails honored

- No changes to `cobra/cmd/`, `main.go`, `box/`, `go.mod`, or `go.sum`.
- No exported API signatures changed.
- Out-of-scope `Fatal` sites in `cobra/aid/{configure,run,workspace,oAuthClient,oAuthToken,sshKey,variable,configurationVersion,helper}.go` and `helper/{cobra,directories,manual,ssh}.go` were not touched (they are programmer-error-only paths or would require widespread call-site changes that conflict with parallel work).

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` shows no new warnings (the pre-existing `tests/cmd_workspace_test.go` warning is unchanged)
- [ ] Reviewer confirms the controller error returns flow through cobra's own error rendering