### PR TITLE
docs: overhaul documentation to AWS style guide

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,78 +1,78 @@
 # Architecture
 
-A one-page tour of the TECLI codebase, current as of the June 2026
-modernization. New contributors should read this before opening their
-first PR; deeper details live in the package-level Go doc and the
-[wiki](https://github.com/awslabs/tecli/wiki).
+This page describes how TECLI is structured, how a command flows from your terminal to the Terraform Cloud API, and the design decisions behind the layout. Read it before you make your first change. Package-level detail lives in the Go doc comments and the [wiki](https://github.com/awslabs/tecli/wiki).
 
-## High-level shape
+## Overview
 
-TECLI is a thin command-line wrapper around
-[`hashicorp/go-tfe`](https://github.com/hashicorp/go-tfe). The binary is
-produced by [`main.go`](main.go), which only calls
-`cmd.Execute()` from the `cobra/cmd` package.
+TECLI is a thin command-line wrapper around [`hashicorp/go-tfe`](https://github.com/hashicorp/go-tfe), the official Go client for the Terraform Cloud (TFC) and Terraform Enterprise (TFE) API. The binary is produced by [`main.go`](main.go), which calls `cmd.Execute()` from the `cobra/cmd` package.
 
-The dependency direction is:
+The command framework is [Cobra](https://github.com/spf13/cobra). Configuration and environment-variable binding use [Viper](https://github.com/spf13/viper).
 
-```
+## Components
+
+The dependency direction flows in one direction, from the command adapters down to the API client:
+
+```text
 cobra/cmd  -->  cobra/controller  -->  cobra/aid  -->  helper/, box/
                                   -->  hashicorp/go-tfe
 ```
 
-Layers below `controller` never import `cmd`; layers below `aid` never
-import `controller`.
+Layers below `controller` do not import `cmd`. Layers below `aid` do not import `controller`.
 
-## Directory layout
+| Path                 | Role                                                                                                                                                                                                                                                                                                           |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `main.go`            | Process entry point. Calls `cmd.Execute()`.                                                                                                                                                                                                                                                                    |
+| `cobra/cmd/`         | Thin adapters. One file per top-level command (`workspace`, `run`, `apply`, `plan`, `configuration-version`, `configure`, `o-auth-client`, `o-auth-token`, `ssh-key`, `variable`, `version`). Each file pulls a `*cobra.Command` from the controller package and registers it on `rootCmd`. No business logic. |
+| `cobra/controller/`  | Business logic. Builds each `cobra.Command` with `Use`, `Short`, `Long`, and `Example` filled from `box/resources/manual/*.yaml`, wires `PreRunE` and `RunE`, validates flags through `helper.ValidateCmdArg*`, and calls `go-tfe`.                                                                            |
+| `cobra/aid/`         | Option builders and file I/O. `SetXxxFlags(cmd)` registers per-command flags. Helpers marshal flag values into `tfe.XxxOptions{}`, read and write the credentials file, and load Viper config.                                                                                                                 |
+| `cobra/dao/`         | Data-access functions that read the organization and tokens from the active profile or environment variables (`configure.go`).                                                                                                                                                                                 |
+| `cobra/model/`       | Plain structs, including `CredentialProfile` used by the `configure` command.                                                                                                                                                                                                                                  |
+| `cobra/view/`        | Output rendering helpers, including the interactive `configure` prompts.                                                                                                                                                                                                                                       |
+| `helper/`            | General utilities: argument and flag validation (`cobra.go`), directory and file helpers, `manual.go` (`GetManual` reads the YAML manuals out of `box`), SSH helpers, and string helpers. No Terraform Cloud domain knowledge.                                                                                 |
+| `box/`               | Embedded resources. `box.go` exposes the embedded blob and `gen.go` regenerates it. `resources/manual/*.yaml` defines each command's `Use`, `Short`, `Long`, and `Example`. `resources/VERSION` holds the version string that `tecli version` prints.                                                          |
+| `clencli/`           | Templates and assets used to render the README and screenshots: `readme.tmpl`, `readme.yaml`, `terminalizer/*.gif`, and `logo.jpeg`.                                                                                                                                                                           |
+| `habits/`            | Submodule hosting shared Make targets included from `Makefile` (for example, `go/build`, `go/fmt`, `go/install`).                                                                                                                                                                                              |
+| `examples/`          | End-user usage examples, such as `examples/gitlab/` for GitLab CI.                                                                                                                                                                                                                                             |
+| `tests/`             | Integration tests that call Terraform Cloud. They require `TFC_*` environment variables or a configured profile. `tests/commands/` holds the per-command test files.                                                                                                                                           |
+| `.github/workflows/` | CI: `build.yml` (per-push build), `publish.yml` (tag-driven release), `release.yml` (release-please).                                                                                                                                                                                                          |
 
-| Path                | Role                                                                                                                                                                                                              |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `main.go`           | Process entry point. Calls `cmd.Execute()`.                                                                                                                                                                       |
-| `cobra/cmd/`        | **Thin adapters.** One file per top-level command (`workspace`, `run`, `apply`, `plan`, `configuration-version`, `configure`, `o-auth-client`, `o-auth-token`, `ssh-key`, `variable`, `version`). Each file pulls a `*cobra.Command` from the controller package and registers it on `rootCmd`. No business logic here. |
-| `cobra/controller/` | **Business logic.** Builds each `cobra.Command` (with `Use`/`Short`/`Long`/`Example` filled from `box/resources/manual/*.yaml`), wires `PreRunE`/`RunE`, validates flags via `helper.ValidateCmdArgs*`, and calls `go-tfe` to talk to Terraform Cloud/Enterprise. |
-| `cobra/aid/`        | **Option builders + file I/O.** `SetXxxFlags(cmd)` registers per-command flags; `helper.go` and friends marshal flag values into `tfe.XxxOptions{}`, read/write the credentials file, and load viper config.       |
-| `cobra/dao/`        | Data-access shims (currently small) for talking to the embedded resources.                                                                                                                                        |
-| `cobra/model/`      | Plain structs. Most notably `CredentialProfile` used by the `configure` command.                                                                                                                                  |
-| `cobra/view/`       | Output rendering helpers.                                                                                                                                                                                         |
-| `helper/`           | **General utilities.** `cobra.go` (arg/flag validation), `directories.go`, `files.go`, `manual.go` (`GetManual` reads YAML manuals out of `box`), `ssh.go`, `strings.go`. No domain knowledge of Terraform Cloud. |
-| `box/`              | **Embedded resources** (legacy `clencli` flow). `box.go` exposes the embedded blob; `gen.go` regenerates it. `resources/manual/*.yaml` defines each cobra command's `Use`/`Short`/`Long`/`Example`. `resources/VERSION` is the version string surfaced by `tecli version`. |
-| `clencli/`          | Templates and assets consumed by `clencli` to render the README and screenshots: `readme.tmpl`, `readme.yaml`, `terminalizer/*.gif`, `logo.jpeg`.                                                                  |
-| `habits/`           | Submodule (currently empty in tree) hosting shared Make targets included from `Makefile` (e.g. `go/build`, `go/fmt`, `go/install`).                                                                                |
-| `examples/`         | End-user-facing usage examples (e.g. `examples/gitlab/` for GitLab CI).                                                                                                                                            |
-| `tests/`            | Integration tests that hit Terraform Cloud — require `TFC_*` env vars or a configured profile to run. `tests/commands/` houses per-command test files.                                                            |
-| `.github/workflows/`| CI: `build.yml` (per-push build), `publish.yml` (tag-driven release), `release.yml` (release-please).                                                                                                              |
+## Data flow
 
-## Adding a new command
+A single command, such as `tecli workspace list`, flows through the layers:
 
-1. Add a YAML manual at `box/resources/manual/<name>.yaml` describing
-   `use`, `short`, `long`, `example`.
+1. `main.go` calls `cmd.Execute()`, which runs the Cobra command tree.
+2. `initConfig` calls `aid.LoadViper()`, which binds the `TFC_*` environment variables and reads the credentials file if one exists.
+3. The matched controller runs `PreRunE` to validate the argument and its required flags.
+4. `RunE` reads the resolved token through `cobra/dao` (environment variable first, then the active profile), builds a `*tfe.Client` with `aid.GetTFEClient`, and calls the matching `go-tfe` method.
+5. The controller prints the API response as JSON.
+
+## Design decisions
+
+- **Thin wrapper over `go-tfe`.** TECLI does not reimplement Terraform Cloud logic. Each command maps to one `go-tfe` call, so the output mirrors the API response. Upgrading `go-tfe` is the main way new API behavior reaches the CLI.
+- **Credentials resolved at call time.** The organization and tokens are read from Viper when a command runs, not bound to global flags. Environment variables (`TFC_*`) override the active profile. The organization is never passed as a command-line flag.
+- **Manuals live in YAML, not in code.** Each command's help text comes from `box/resources/manual/<name>.yaml`. Help text changes do not require touching Go source.
+- **One-directional layering.** The `cmd` -> `controller` -> `aid` -> `helper`/`box` dependency direction keeps adapters free of business logic and keeps utilities free of Terraform Cloud knowledge.
+
+## Adding a command
+
+1. Add a YAML manual at `box/resources/manual/<name>.yaml` describing `use`, `short`, `long`, and `example`.
 2. Add `cobra/controller/<name>.go` that:
    - Declares `var <name>ValidArgs = []string{ ... }`.
    - Builds a `*cobra.Command` from `helper.GetManual("<name>", validArgs)`.
-   - Implements `<name>PreRun` (flag validation) and `<name>Run`
-     (calls go-tfe).
-3. Add `cobra/aid/<name>.go` with `SetXxxFlags(cmd *cobra.Command)`
-   and option-builder helpers.
-4. Register the command in `cobra/cmd/<name>.go` and add the
-   `rootCmd.AddCommand(<name>Cmd)` call.
-5. Run `go build ./...` and `go vet ./...`. If the command has tests,
-   add them under `tests/commands/`.
-6. Document the new command in `COMMANDS.md` and (if relevant)
-   `TOP-COMMANDS.md`.
+   - Implements `<name>PreRun` for flag validation and `<name>Run` to call `go-tfe`.
+3. Add `cobra/aid/<name>.go` with `SetXxxFlags(cmd *cobra.Command)` and the option-builder helpers.
+4. Register the command in `cobra/cmd/<name>.go` and add the `rootCmd.AddCommand(<name>Cmd)` call.
+5. Run `go build ./...` and `go vet ./...`. Add tests under `tests/commands/` if the command needs them.
+6. Document the command in [COMMANDS.md](COMMANDS.md) and, if it is a common task, in [TOP-COMMANDS.md](TOP-COMMANDS.md).
 
-## Configuration & credentials
+## Configuration and credentials
 
-`tecli configure create` writes a YAML credentials file under
-`~/.tecli/credentials.yaml` with one or more named profiles. Each
-profile holds `organization`, `user-token`, `team-token`, and
-`organization-token`. The same values can be supplied via
-`TFC_ORGANIZATION`, `TFC_USER_TOKEN`, `TFC_TEAM_TOKEN`, and
-`TFC_ORGANIZATION_TOKEN` environment variables (env wins).
+`tecli configure create` writes a YAML credentials file named `credentials.yaml` under the user configuration directory (for example, `~/Library/Application Support/tecli/credentials.yaml` on macOS or `~/.config/tecli/credentials.yaml` on Linux). Each profile holds `organization`, `user-token`, `team-token`, and `organization-token`. The same values can come from the `TFC_ORGANIZATION`, `TFC_USER_TOKEN`, `TFC_TEAM_TOKEN`, and `TFC_ORGANIZATION_TOKEN` environment variables, which take precedence.
 
-Most commands accept `--profile`/`-p` (default: `default`) so a single
-host can target multiple Terraform organizations.
+Most commands accept `--profile`/`-p` (default `default`), so one host can target multiple Terraform Cloud organizations.
 
-## Build & release entry points
+## Build and release
 
-- Local build: `go build ./...` (requires Go 1.25+).
-- Cross-compile: `make tecli/compile` (writes binaries to `dist/`).
-- Release: see [`docs/RELEASING.md`](docs/RELEASING.md).
+- Local build: `go build ./...`. Requires Go 1.25 or later.
+- Cross-compile: `make tecli/compile` writes binaries to `dist/`.
+- Release: see [docs/RELEASING.md](docs/RELEASING.md).

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,109 +1,312 @@
 # Commands
 
-This file is the canonical, hand-maintained map of every TECLI
-subcommand. Each section corresponds to one `*ValidArgs` slice in
-[`cobra/controller/`](cobra/controller/), so `grep cobra.Command{
-cobra/controller/` is the source of truth if these ever drift.
+This is the full command reference for TECLI. It is verified against the `*ValidArgs` slices and flag definitions in [`cobra/controller/`](cobra/controller/) and [`cobra/aid/`](cobra/aid/).
 
-`tecli --help` prints the live top-level list. If you spot a
-divergence between this file and `tecli --help`, please open an issue
-or PR.
+Run `tecli --help` for the live top-level list and `tecli <command> --help` for flag-level help. If this file and `tecli --help` disagree, open an issue or a pull request.
 
-## Top-level commands
+## Conventions
 
-```text
-Command Line Interface for Terraform Enterprise/Cloud
+- A command has the form `tecli <command> <argument> [flags]`.
+- `<command>` is a resource. `<argument>` is the operation, such as `list` or `create`.
+- The organization and API tokens are not command-line flags. TECLI reads them from the `TFC_*` environment variables or the active profile. See [Configuration](README.md#configuration).
+- Identifiers such as `--id` and `--workspace-id` are Terraform Cloud resource IDs (for example, `ws-XXXXXXXX`), not names.
 
-Usage:
-  tecli [command]
+## Persistent flags
 
-Available Commands:
-  apply                 An apply represents the results of applying a Terraform Run's execution plan.
-  configuration-version A configuration version is a resource used to reference the uploaded configuration files.
-  configure             Configures tecli settings
-  help                  Help about any command
-  o-auth-client         An OAuth Client represents the connection between an organization and a VCS provider.
-  o-auth-token          The oauth-token object represents a VCS configuration which includes the OAuth connection and the associated OAuth token. This object is used when creating a workspace to identify which VCS connection to use.
-  plan                  A plan represents the execution plan of a Run in a Terraform workspace.
-  run                   A run performs a plan and apply, using a configuration version and the workspace's current variables.
-  ssh-key               The ssh-key object represents an SSH key which includes a name and the SSH private key. An organization can have multiple SSH keys available.
-  variable              Operations on variables.
-  version               Displays the version of tecli and all installed plugins
-  workspace             Workspaces represent running infrastructure managed by Terraform.
+These flags are available on every command.
 
-Flags:
-  -h, --help             help for this command
-  -p, --profile string   Use a specific profile from your credentials and configurations file. (default "default")
+| Flag              | Default   | Description                                        |
+| ----------------- | --------- | -------------------------------------------------- |
+| `-p`, `--profile` | `default` | Selects a named profile from the credentials file. |
+| `-h`, `--help`    |           | Prints help for the command.                       |
 
-Use "tecli [command] --help" for more information about a command.
+## `tecli configure`
+
+Manages the TECLI credentials file. `configure` reads and writes the credentials file only. It does not use environment variables.
+
+Arguments: `list`, `create`, `read`, `update`, `delete`.
+
+| Flag                   | Default       | Description                                                      |
+| ---------------------- | ------------- | ---------------------------------------------------------------- |
+| `--mode`               | `interactive` | `interactive` prompts for values; `non-interactive` reads flags. |
+| `--new-name`           |               | New profile name for `update`.                                   |
+| `--description`        |               | Profile description.                                             |
+| `--user-token`         |               | User API token (non-interactive mode).                           |
+| `--team-token`         |               | Team API token (non-interactive mode).                           |
+| `--organization-token` |               | Organization API token (non-interactive mode).                   |
+
+```bash
+# Create the default profile interactively
+tecli configure create
+
+# Create a named profile non-interactively
+tecli configure create --profile cicd --mode non-interactive \
+  --team-token "${TFC_TEAM_TOKEN}"
+
+# Read and list profiles
+tecli configure read --profile cicd
+tecli configure list
+
+# Delete a profile
+tecli configure delete --profile cicd
 ```
 
-## Subcommands
+## `tecli workspace`
 
-Use `tecli <command> --help` to see flag-level help. The lists below
-are extracted from the `*ValidArgs` definitions in
-`cobra/controller/`.
+Manages workspaces. Viewing a workspace requires permission to read runs. Changing settings and force-unlocking require admin access. Locking and unlocking require lock and unlock permission.
 
-### `tecli apply`
+Arguments: `list`, `create`, `read`, `read-by-id`, `update`, `update-by-id`, `delete`, `delete-by-id`, `find-by-name`, `lock`, `unlock`, `force-unlock`, `assign-ssh-key`, `unassign-ssh-key`, `remove-vcs-connection`, `remove-vcs-connection-by-id`.
 
-`read`, `logs`
+Name-based arguments (`create`, `read`, `update`, `delete`, `find-by-name`, `remove-vcs-connection`) require `--name`. ID-based arguments (`read-by-id`, `update-by-id`, `delete-by-id`, `remove-vcs-connection-by-id`, `lock`, `unlock`, `force-unlock`, `assign-ssh-key`, `unassign-ssh-key`) require `--id`.
 
-### `tecli configuration-version`
+| Flag                            | Type        | Description                                            |
+| ------------------------------- | ----------- | ------------------------------------------------------ |
+| `--id`                          | string      | Workspace ID (`ws-XXXXXXXX`).                          |
+| `--name`                        | string      | Workspace name.                                        |
+| `--new-name`                    | string      | New name for `update`.                                 |
+| `--search`                      | string      | Search filter for `list`.                              |
+| `--include`                     | string      | Related resources to include in `list`.                |
+| `--agent-pool-id`               | string      | Agent pool ID.                                         |
+| `--allow-destroy-plan`          | bool        | Allow destroy plans.                                   |
+| `--auto-apply`                  | bool        | Apply runs automatically.                              |
+| `--execution-mode`              | string      | Execution mode (`remote`, `local`, `agent`).           |
+| `--file-triggers-enabled`       | bool        | Trigger runs on file changes in `--trigger-prefixes`.  |
+| `--migration-environment`       | string      | Legacy migration environment.                          |
+| `--queue-all-runs`              | bool        | Queue all runs on creation.                            |
+| `--speculative-enabled`         | bool        | Allow speculative plans.                               |
+| `--terraform-version`           | string      | Terraform version for the workspace.                   |
+| `--trigger-prefixes`            | stringArray | Path prefixes that trigger runs.                       |
+| `--working-directory`           | string      | Working directory for Terraform.                       |
+| `--reason`                      | string      | Reason for `lock`.                                     |
+| `--ssh-key-id`                  | string      | SSH key ID for `assign-ssh-key`.                       |
+| `--vcs-repo-branch`             | string      | VCS branch.                                            |
+| `--vcs-repo-identifier`         | string      | VCS repository identifier (`org/repo`).                |
+| `--vcs-repo-ingress-submodules` | bool        | Fetch submodules when cloning.                         |
+| `--vcs-repo-oauth-token-id`     | string      | OAuth token ID for the VCS connection (`ot-XXXXXXXX`). |
 
-`list`, `create`, `read`, `upload`
+```bash
+# List workspaces in the organization on the active profile
+tecli workspace list
 
-### `tecli configure`
+# Find a workspace by name
+tecli workspace find-by-name --name your-workspace
 
-`list`, `create`, `read`, `update`, `delete`
+# Create a workspace that allows destroy plans
+tecli workspace create --name your-workspace --allow-destroy-plan=true
 
-### `tecli o-auth-client`
+# Create a workspace connected to a VCS repository
+tecli workspace create \
+  --name your-workspace \
+  --vcs-repo-oauth-token-id ot-XXXXXXXX \
+  --vcs-repo-identifier org/repo
 
-`list`, `create`, `read`, `delete`
+# Lock and unlock a workspace by ID
+tecli workspace lock --id ws-XXXXXXXX
+tecli workspace unlock --id ws-XXXXXXXX
+```
 
-### `tecli o-auth-token`
+## `tecli run`
 
-`list`, `read`, `update`, `delete`
+Manages runs. A run performs a plan and apply using a configuration version and the workspace's current variables.
 
-### `tecli plan`
+Arguments: `list`, `create`, `read`, `read-with-options`, `apply`, `cancel`, `cancel-all`, `force-cancel`, `force-cancel-all`, `discard`, `discard-all`.
 
-`read`, `logs`
+`list`, `create`, `cancel-all`, `force-cancel-all`, and `discard-all` operate on a workspace and require `--workspace-id`. `read`, `read-with-options`, `apply`, `cancel`, `force-cancel`, and `discard` operate on a single run and require `--id`.
 
-### `tecli run`
+| Flag                         | Type        | Description                                                   |
+| ---------------------------- | ----------- | ------------------------------------------------------------- |
+| `--id`                       | string      | Run ID (`run-XXXXXXXX`).                                      |
+| `--workspace-id`             | string      | Workspace ID (`ws-XXXXXXXX`).                                 |
+| `--configuration-version-id` | string      | Configuration version ID to run against.                      |
+| `--message`                  | string      | Message associated with the run (used by `create`).           |
+| `--comment`                  | string      | Comment for `apply`, `cancel`, `force-cancel`, and `discard`. |
+| `--is-destroy`               | bool        | Create a destroy run.                                         |
+| `--target-addrs`             | stringArray | Resource addresses to target.                                 |
+| `--include`                  | string      | Related resources to include in the read.                     |
 
-`list`, `create`, `read`, `read-with-options`, `apply`, `cancel`,
-`cancel-all`, `force-cancel`, `force-cancel-all`, `discard`,
-`discard-all`
+```bash
+# Create a run on a workspace
+tecli run create --workspace-id ws-XXXXXXXX --message "Initial run"
 
-### `tecli ssh-key`
+# Create a destroy run
+tecli run create --workspace-id ws-XXXXXXXX --message "Tear down" --is-destroy=true
 
-`list`, `create`, `read`, `update`, `delete`
+# Read a run
+tecli run read --id run-XXXXXXXX
 
-### `tecli variable`
+# Apply a run with a comment
+tecli run apply --id run-XXXXXXXX --comment "Applying changes"
 
-`list`, `create`, `read`, `update`, `update-by-key`, `delete`,
-`delete-all`
+# Discard one run, or every run queued on a workspace
+tecli run discard --id run-XXXXXXXX
+tecli run discard-all --workspace-id ws-XXXXXXXX
+```
 
-### `tecli version`
+## `tecli plan`
 
-No subcommands. Prints the version stored in
-`box/resources/VERSION`.
+Reads plans and plan logs. A plan is the execution plan of a run.
 
-### `tecli workspace`
+Arguments: `read`, `logs`. Both require `--id` (the plan ID).
 
-`list`, `create`, `read`, `read-by-id`, `update`, `update-by-id`,
-`delete`, `delete-by-id`, `find-by-name`, `lock`, `unlock`,
-`force-unlock`, `assign-ssh-key`, `unassign-ssh-key`,
-`remove-vcs-connection`, `remove-vcs-connection-by-id`
+| Flag   | Type   | Description |
+| ------ | ------ | ----------- |
+| `--id` | string | Plan ID.    |
 
-## Common flags
+```bash
+tecli plan read --id plan-XXXXXXXX
+tecli plan logs --id plan-XXXXXXXX
+```
 
-- `-p, --profile string` (persistent, default `default`) — selects a
-  named profile from `~/.tecli/credentials.yaml`.
-- `-h, --help` — per-command help. Always available.
+## `tecli apply`
 
-## Cross-references
+Reads applies and apply logs. An apply represents the results of applying a run's execution plan.
 
-- One-liner recipes for the most common workflows live in
-  [`TOP-COMMANDS.md`](TOP-COMMANDS.md).
-- Architectural background (where these commands live in the codebase)
-  is in [`ARCHITECTURE.md`](ARCHITECTURE.md).
+Arguments: `read`, `logs`. Both require `--id` (the apply ID).
+
+| Flag   | Type   | Description |
+| ------ | ------ | ----------- |
+| `--id` | string | Apply ID.   |
+
+```bash
+tecli apply read --id apply-XXXXXXXX
+tecli apply logs --id apply-XXXXXXXX
+```
+
+## `tecli configuration-version`
+
+Manages configuration versions. A configuration version references the uploaded configuration files used by a run.
+
+Arguments: `list`, `create`, `read`, `upload`. `list` and `create` require `--workspace-id`. `read` requires `--id`. `upload` requires `--url` and `--path`.
+
+| Flag                | Type   | Description                                               |
+| ------------------- | ------ | --------------------------------------------------------- |
+| `--id`              | string | Configuration version ID (`cv-XXXXXXXX`).                 |
+| `--workspace-id`    | string | Workspace ID (`ws-XXXXXXXX`).                             |
+| `--auto-queue-runs` | bool   | Queue a run automatically after upload.                   |
+| `--speculative`     | bool   | Mark the configuration version as speculative.            |
+| `--url`             | string | Upload URL returned by `create` (used by `upload`).       |
+| `--path`            | string | Local path to the configuration files (used by `upload`). |
+
+```bash
+# Create a configuration version and capture the upload URL
+tecli configuration-version create --workspace-id ws-XXXXXXXX
+
+# Upload configuration files to that URL
+tecli configuration-version upload --url https://archivist.terraform.io/... --path ./
+
+# Read a configuration version
+tecli configuration-version read --id cv-XXXXXXXX
+```
+
+## `tecli variable`
+
+Manages Terraform and environment variables on a workspace.
+
+Arguments: `list`, `create`, `read`, `update`, `update-by-key`, `delete`, `delete-all`. `list`, `create`, and `delete-all` operate on a workspace and require `--workspace-id`. `read`, `update`, and `delete` require `--id`. `update-by-key` matches a variable by `--key`.
+
+| Flag             | Type   | Description                     |
+| ---------------- | ------ | ------------------------------- |
+| `--id`           | string | Variable ID (`var-XXXXXXXX`).   |
+| `--workspace-id` | string | Workspace ID (`ws-XXXXXXXX`).   |
+| `--key`          | string | Variable key.                   |
+| `--value`        | string | Variable value.                 |
+| `--description`  | string | Variable description.           |
+| `--category`     | string | `terraform` or `env`.           |
+| `--hcl`          | bool   | Parse the value as HCL.         |
+| `--sensitive`    | bool   | Mark the variable as sensitive. |
+
+```bash
+# Create a sensitive Terraform variable
+tecli variable create \
+  --workspace-id ws-XXXXXXXX \
+  --key your-key \
+  --value your-value \
+  --category terraform \
+  --sensitive=true
+
+# Create a sensitive environment variable
+tecli variable create \
+  --workspace-id ws-XXXXXXXX \
+  --key AWS_SECRET_ACCESS_KEY \
+  --value your-secret-key \
+  --category env \
+  --sensitive=true
+
+# Update a variable by key
+tecli variable update-by-key --workspace-id ws-XXXXXXXX --key your-key --value new-value
+
+# Delete every variable on a workspace
+tecli variable delete-all --workspace-id ws-XXXXXXXX
+```
+
+## `tecli ssh-key`
+
+Manages SSH keys. SSH keys are used by VCS integrations and by workspaces that clone modules from a Git server. The list and read operations return metadata only; Terraform Cloud never returns the private key text.
+
+Arguments: `list`, `create`, `read`, `update`, `delete`. `read`, `update`, and `delete` require `--id`.
+
+| Flag      | Type   | Description                                          |
+| --------- | ------ | ---------------------------------------------------- |
+| `--id`    | string | SSH key ID. Required for `read`, `update`, `delete`. |
+| `--name`  | string | Name to identify the SSH key.                        |
+| `--value` | string | Content of the SSH private key.                      |
+
+```bash
+tecli ssh-key list
+tecli ssh-key read --id sshkey-XXXXXXXX
+tecli ssh-key delete --id sshkey-XXXXXXXX
+```
+
+## `tecli o-auth-client`
+
+Manages OAuth clients. An OAuth client represents the connection between an organization and a VCS provider.
+
+Arguments: `list`, `create`, `read`, `delete`. `read` and `delete` require `--id`.
+
+| Flag                 | Type   | Description                        |
+| -------------------- | ------ | ---------------------------------- |
+| `--id`               | string | OAuth client ID (`oc-XXXXXXXX`).   |
+| `--api-url`          | string | VCS provider API URL.              |
+| `--http-url`         | string | VCS provider HTTP URL.             |
+| `--o-auth-token`     | string | OAuth token from the VCS provider. |
+| `--private-key`      | string | Private key for the connection.    |
+| `--service-provider` | string | VCS service provider type.         |
+
+```bash
+tecli o-auth-client list
+tecli o-auth-client read --id oc-XXXXXXXX
+tecli o-auth-client delete --id oc-XXXXXXXX
+```
+
+## `tecli o-auth-token`
+
+Manages OAuth tokens. An OAuth token is the VCS configuration used when you create a workspace connected to a repository.
+
+Arguments: `list`, `read`, `update`, `delete`. `read`, `update`, and `delete` require `--id`.
+
+| Flag                | Type   | Description                                    |
+| ------------------- | ------ | ---------------------------------------------- |
+| `--id`              | string | OAuth token ID (`ot-XXXXXXXX`).                |
+| `--private-ssh-key` | string | Private SSH key used for git clone operations. |
+
+```bash
+# List OAuth tokens to find the ID for a VCS connection
+tecli o-auth-token list
+
+# Set the private SSH key on an OAuth token
+private_ssh_key="$(cat ~/.ssh/id_rsa)"
+tecli o-auth-token update --id ot-XXXXXXXX --private-ssh-key "${private_ssh_key}"
+```
+
+## `tecli version`
+
+Prints the TECLI version. The version string is read from `box/resources/VERSION`. This command takes no arguments.
+
+```bash
+tecli version
+```
+
+## Related references
+
+- Copy-paste recipes for common tasks: [TOP-COMMANDS.md](TOP-COMMANDS.md).
+- Where these commands live in the codebase: [ARCHITECTURE.md](ARCHITECTURE.md).

--- a/README.md
+++ b/README.md
@@ -1,62 +1,43 @@
-# TECLI - Terraform Enterprise/Cloud Command Line Interface
+# TECLI
 
-<div align="center">
-
-![TECLI Logo](clencli/logo.jpeg)
+A command-line interface for the Terraform Cloud and Terraform Enterprise API.
 
 [![GitHub issues](https://img.shields.io/github/issues/awslabs/tecli)](https://github.com/awslabs/tecli/issues)
 [![GitHub forks](https://img.shields.io/github/forks/awslabs/tecli)](https://github.com/awslabs/tecli/network)
 [![GitHub stars](https://img.shields.io/github/stars/awslabs/tecli)](https://github.com/awslabs/tecli/stargazers)
 [![GitHub license](https://img.shields.io/github/license/awslabs/tecli)](https://github.com/awslabs/tecli/blob/main/LICENSE)
-[![Twitter](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Fawslabs%2Ftecli)](https://twitter.com/intent/tweet?text=Wow:&url=https%3A%2F%2Fgithub.com%2Fawslabs%2Ftecli)
 
-</div>
+## Overview
 
-## 📖 Overview
+TECLI (Terraform Enterprise/Cloud Command Line Interface) wraps the [Terraform Cloud API](https://www.terraform.io/docs/cloud/api/index.html) so you can manage Terraform Cloud (TFC) and Terraform Enterprise (TFE) resources from a terminal or a CI/CD pipeline. It is built on the official [`hashicorp/go-tfe`](https://github.com/hashicorp/go-tfe) Go client.
 
-TECLI is a powerful command-line interface designed to interact with [Terraform Cloud API](https://www.terraform.io/docs/cloud/api/index.html). It enhances team productivity by providing intuitive commands that can be executed in a terminal or integrated into CI/CD pipelines.
+You use TECLI to manage workspaces, runs, plans, applies, variables, configuration versions, SSH keys, and VCS (OAuth) connections without leaving the command line. Each command maps to a Terraform Cloud API resource, so the output is the JSON the API returns.
 
-In a world where infrastructure as code is becoming the standard, TECLI bridges the gap between your workflows and Terraform Cloud, making it easier to manage workspaces, runs, variables, and more.
+This tool is for platform engineers and infrastructure teams who automate Terraform Cloud or Terraform Enterprise operations.
 
-## 🚀 Features
+## Features
 
-- **Workspace Management**: Create, read, update, delete, and list Terraform workspaces
-- **Run Operations**: Create, apply, and discard Terraform runs
-- **Plan & Apply Management**: View logs for plan and apply operations
-- **Variable Management**: Create, update, and delete Terraform and environment variables
-- **VCS Integration**: Connect workspaces to version control repositories
-- **SSH Key Management**: Manage SSH keys for private module access
-- **OAuth Client Management**: Configure OAuth clients for VCS providers
+- Manage workspaces: list, create, read, update, delete, lock, unlock, and connect to a VCS repository.
+- Manage runs: create, read, apply, cancel, force-cancel, and discard.
+- Read plan and apply logs.
+- Manage Terraform and environment variables on a workspace.
+- Upload configuration versions for a run.
+- Manage SSH keys for private module access.
+- Manage OAuth clients and tokens for VCS provider integrations.
+- Select between multiple Terraform Cloud organizations using named profiles.
 
-## 📋 Table of Contents
+## Prerequisites
 
-- [Installation](#-installation)
-- [Configuration](#-configuration)
-- [Usage Examples](#-usage-examples)
-- [Command Reference](#-command-reference)
-- [Common Workflows](#-common-workflows)
-- [Screenshots](#-screenshots)
-- [Contributing](#-contributing)
-- [History](#-history)
-- [References](#-references)
-- [License](#-license)
+- A Terraform Cloud or Terraform Enterprise account.
+- An API token. The token you need depends on the operation: a [user, team, or organization token](https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html). Most workspace and run operations use a team token.
+- Go 1.25 or later, only if you build from source.
 
-## 📥 Installation
-
-### Prerequisites
-
-Before installing TECLI, ensure you have:
-
-- A Terraform Cloud or Terraform Enterprise account
-- Appropriate API tokens (user, team, or organization)
-- Go 1.25 or later (only required if building from source)
-
-For more detailed prerequisites, visit our [Pre-Requisites Wiki](https://github.com/awslabs/tecli/wiki/Pre-Requisites).
+## Installation
 
 ### Install a pre-built binary
 
-1. Download the latest [release](https://github.com/awslabs/tecli/releases) for your operating system and platform.
-2. Extract the binary to a location in your `PATH`.
+1. Download the latest [release](https://github.com/awslabs/tecli/releases) for your operating system and architecture.
+2. Extract the binary to a directory on your `PATH`.
 3. Verify the installation:
 
 ```bash
@@ -68,268 +49,153 @@ tecli version
 ```bash
 git clone https://github.com/awslabs/tecli.git
 cd tecli
-go build -o tecli ./...
+go build -o tecli .
 ./tecli version
 ```
 
-`go build` requires Go 1.25+. The Terraform Cloud/Enterprise client used internally is [hashicorp/go-tfe v1.108+](https://pkg.go.dev/github.com/hashicorp/go-tfe).
+Building from source requires Go 1.25 or later. The Terraform Cloud client is [`hashicorp/go-tfe`](https://pkg.go.dev/github.com/hashicorp/go-tfe) v1.108.0.
 
-For more detailed installation instructions, visit our [Installation Wiki](https://github.com/awslabs/tecli/wiki/Installation).
+## Getting started
 
-## ⚙️ Configuration
-
-TECLI requires configuration before use. You can configure it in two ways:
-
-### Using the Configure Command
+1. Create a profile. The interactive prompt asks for your organization and tokens:
 
 ```bash
 tecli configure create
 ```
 
-This interactive command will guide you through setting up your profile with:
-- Organization name
-- User token
-- Team token
-- Organization token
-
-### Using Environment Variables
+2. List the workspaces in your organization to confirm the credentials work:
 
 ```bash
-# Linux/macOS
+tecli workspace list
+```
+
+TECLI reads the organization and tokens from the active profile or from environment variables. You do not pass the organization on the command line. See [Configuration](#configuration).
+
+## Usage
+
+A command follows this structure:
+
+```bash
+tecli <command> <argument> [flags]
+```
+
+`<command>` is a resource such as `workspace` or `run`. `<argument>` is the operation such as `list` or `create`. The persistent `--profile` flag selects which credentials profile to use.
+
+List all workspaces in the organization on the active profile:
+
+```bash
+tecli workspace list
+```
+
+Find a workspace by name:
+
+```bash
+tecli workspace find-by-name --name your-workspace-name
+```
+
+Create a workspace:
+
+```bash
+tecli workspace create --name your-workspace-name --allow-destroy-plan=true
+```
+
+Create a workspace connected to a VCS repository:
+
+```bash
+# List OAuth tokens to find the token ID
+tecli o-auth-token list
+
+# Create the workspace with the VCS connection
+tecli workspace create \
+  --name your-workspace-name \
+  --vcs-repo-oauth-token-id ot-XXXXXXXX \
+  --vcs-repo-identifier org/repo
+```
+
+Create and apply a run:
+
+```bash
+# Create a configuration version on the workspace
+tecli configuration-version create --workspace-id ws-XXXXXXXX
+
+# Upload the configuration files to the returned upload URL
+tecli configuration-version upload --url https://archivist.terraform.io/... --path ./
+
+# Create a run
+tecli run create --workspace-id ws-XXXXXXXX --message "Initial run"
+
+# Read the run status
+tecli run read --id run-XXXXXXXX
+
+# Apply the run
+tecli run apply --id run-XXXXXXXX --comment "Applying changes"
+```
+
+For the full command reference, see [COMMANDS.md](COMMANDS.md). For copy-paste recipes covering the most common tasks, see [TOP-COMMANDS.md](TOP-COMMANDS.md).
+
+## Configuration
+
+TECLI reads the organization and API tokens in this precedence order:
+
+1. `TFC_*` environment variables.
+2. The active profile in the credentials file.
+
+### Credentials file
+
+`tecli configure create` writes a YAML credentials file named `credentials.yaml` under the user configuration directory:
+
+- macOS: `~/Library/Application Support/tecli/credentials.yaml`
+- Linux: `~/.config/tecli/credentials.yaml` (or `$XDG_CONFIG_HOME/tecli/credentials.yaml`)
+- Windows: `%AppData%\tecli\credentials.yaml`
+
+Each profile holds an `organization`, `user-token`, `team-token`, and `organization-token`. You select a profile with the persistent `--profile`/`-p` flag (default `default`), so one host can target multiple organizations.
+
+### Environment variables
+
+Set the following environment variables to override the profile values. Environment variables take precedence over the credentials file.
+
+```bash
+# Linux and macOS
 export TFC_ORGANIZATION=your-organization
 export TFC_USER_TOKEN=your-user-token
 export TFC_TEAM_TOKEN=your-team-token
 export TFC_ORGANIZATION_TOKEN=your-organization-token
+```
 
+```powershell
 # Windows (PowerShell)
-$Env:TFC_ORGANIZATION="your-organization"
-$Env:TFC_USER_TOKEN="your-user-token"
-$Env:TFC_TEAM_TOKEN="your-team-token"
-$Env:TFC_ORGANIZATION_TOKEN="your-organization-token"
+$Env:TFC_ORGANIZATION = "your-organization"
+$Env:TFC_USER_TOKEN = "your-user-token"
+$Env:TFC_TEAM_TOKEN = "your-team-token"
+$Env:TFC_ORGANIZATION_TOKEN = "your-organization-token"
 ```
 
-## 🔍 Usage Examples
+The `configure` command reads and writes the credentials file only. It does not use environment variables.
 
-### Basic Command Structure
+## Architecture
 
-```bash
-tecli <resource> <action> [flags]
-```
+TECLI is a thin command-line wrapper around `hashicorp/go-tfe`. The `main` package calls `cmd.Execute()`, which builds a Cobra command tree. Each command validates flags, marshals them into `go-tfe` option structs, calls the Terraform Cloud API, and prints the JSON response. For components, data flow, and design decisions, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
-### List All Workspaces
+## Troubleshooting
 
-```bash
-tecli workspace list --organization=your-organization
-```
+- **`workspace list` returns no workspaces or an authentication error.** Confirm the active profile has an organization and the matching token set, or that the `TFC_*` environment variables are exported in the current shell. Run `tecli configure read` to inspect the active profile.
+- **A command reports it cannot find a workspace by ID.** Commands that take `--id` or `--workspace-id` expect a Terraform Cloud resource ID (for example, `ws-XXXXXXXX`), not a name. Use `--name` with the name-based subcommands such as `workspace find-by-name`.
+- **The wrong organization is used.** The `TFC_ORGANIZATION` environment variable overrides the profile. Unset it to fall back to the profile value.
 
-### Find a Workspace by Name
+## Contributing
 
-```bash
-tecli workspace find-by-name --organization=your-organization --name=your-workspace-name
-```
+See [Contributing](CONTRIBUTING.md).
 
-### Create a Workspace
+## Security
 
-```bash
-tecli workspace create --organization=your-organization --name=your-workspace-name --allow-destroy-plan=true
-```
+See [Security](SECURITY.md) for vulnerability reporting.
 
-### Create a Workspace with VCS Repository
+## License
 
-```bash
-# First, get the OAuth Token ID
-tecli o-auth-token list --organization=your-organization
-
-# Then create the workspace with VCS connection
-tecli workspace create \
-  --organization=your-organization \
-  --name=your-workspace-name \
-  --vcs-repo-oauth-token-id=your-oauth-token-id \
-  --vcs-repo-identifier=org/repo
-```
-
-### Create and Apply a Run
-
-```bash
-# Create a configuration version
-tecli configuration-version create --workspace-id=your-workspace-id
-
-# Upload configuration files
-tecli configuration-version upload --url=your-upload-url --path=./
-
-# Create a run
-tecli run create --workspace-id=your-workspace-id --comment="Your comment"
-
-# Check run status
-tecli run read --id=your-run-id
-
-# Apply the run
-tecli run apply --id=your-run-id --comment="Apply comment"
-```
-
-### Manage Variables
-
-```bash
-# Create a sensitive Terraform variable
-tecli variable create \
-  --key=your-variable-key \
-  --value=your-variable-value \
-  --workspace-id=your-workspace-id \
-  --category=terraform \
-  --sensitive=true
-
-# Create AWS environment variables
-tecli variable create --key=AWS_ACCESS_KEY_ID --value=your-access-key --workspace-id=your-workspace-id --category=env --sensitive=true
-tecli variable create --key=AWS_SECRET_ACCESS_KEY --value=your-secret-key --workspace-id=your-workspace-id --category=env --sensitive=true
-tecli variable create --key=AWS_DEFAULT_REGION --value=your-region --workspace-id=your-workspace-id --category=env --sensitive=true
-```
-
-## 📚 Command Reference
-
-TECLI provides the following main commands:
-
-```
-Available Commands:
-  apply                 An apply represents the results of applying a Terraform Run's execution plan.
-  configuration-version A configuration version is a resource used to reference the uploaded configuration files.
-  configure             Configures tecli settings
-  help                  Help about any command
-  o-auth-client         An OAuth Client represents the connection between an organization and a VCS provider.
-  o-auth-token          The oauth-token object represents a VCS configuration which includes the OAuth connection and the associated OAuth token.
-  plan                  A plan represents the execution plan of a Run in a Terraform workspace.
-  run                   A run performs a plan and apply, using a configuration version and the workspace's current variables.
-  ssh-key               The ssh-key object represents an SSH key which includes a name and the SSH private key.
-  variable              Operations on variables.
-  version               Displays the version of tecli and all installed plugins
-  workspace             Workspaces represent running infrastructure managed by Terraform.
-```
-
-For detailed information about a specific command:
-
-```bash
-tecli [command] --help
-```
-
-## 🔄 Common Workflows
-
-### Complete Terraform Run Workflow
-
-```bash
-# Create a workspace
-tecli workspace create --organization=your-org --name=your-workspace
-
-# Create a configuration version
-tecli configuration-version create --workspace-id=your-workspace-id
-
-# Upload configuration files
-tecli configuration-version upload --url=your-upload-url --path=./
-
-# Create a run
-tecli run create --workspace-id=your-workspace-id --comment="Initial run"
-
-# Monitor run status
-tecli run read --id=your-run-id
-
-# View plan logs
-tecli plan logs --id=your-plan-id
-
-# Apply the run
-tecli run apply --id=your-run-id --comment="Applying changes"
-
-# View apply logs
-tecli apply logs --id=your-apply-id
-```
-
-### Monitoring and Waiting for Run Completion
-
-```bash
-# Bash script to wait for run completion
-while true; do 
-  STATUS=$(tecli run read --id=your-run-id | jq -r ".Status")
-  if [ "${STATUS}" != "pending" ]; then 
-    break
-  else 
-    echo "RUN STATUS:${STATUS}, IF 'pending' TRY DISCARD PREVIOUS PLANS. SLEEP 5 seconds" && sleep 5
-  fi
-done
-```
-
-## 📸 Screenshots
-
-<details>
-<summary>Click to expand screenshots</summary>
-
-| ![How to configure](clencli/terminalizer/configure.gif) |
-| :-----------------------------------------------------: |
-|                   _How to configure_                    |
-
-| ![How to create a workspace](clencli/terminalizer/workspace-create.gif) |
-| :---------------------------------------------------------------------: |
-|                       _How to create a workspace_                       |
-
-| ![How to create a workspace linked to a repository](clencli/terminalizer/workspace-with-vcs-repo.gif) |
-| :---------------------------------------------------------------------------------------------------: |
-|                          _How to create a workspace linked to a repository_                           |
-
-| ![How to create a run](clencli/terminalizer/run-create.gif) |
-| :---------------------------------------------------------: |
-|                    _How to create a run_                    |
-
-| ![How to read plan logs](clencli/terminalizer/plan-logs.gif) |
-| :----------------------------------------------------------: |
-|                   _How to read plan logs_                    |
-
-| ![How to read apply logs](clencli/terminalizer/apply-logs.gif) |
-| :------------------------------------------------------------: |
-|                    _How to read apply logs_                    |
-
-| ![How to delete a workspace](clencli/terminalizer/workspace-delete.gif) |
-| :---------------------------------------------------------------------: |
-|                       _How to delete a workspace_                       |
-
-</details>
-
-## 👥 Contributing
-
-We welcome contributions to TECLI! Please read our [Contributing Guidelines](CONTRIBUTING.md) for details on how to submit pull requests, report issues, and suggest improvements.
-
-### Contributors
-
-| Name | Email | Role |
-| :--: | :---: | :--: |
-| Silva, Valter | valterh@amazon.com | AWS Professional Services - Cloud Architect |
-| Dhingra, Prashit | | AWS Professional Services - Cloud Architect |
-
-## 🕒 History
-
-See [`CHANGELOG.md`](CHANGELOG.md) for the full release history.
-
-### Modernization 2026-06
-
-A toolchain modernization pass was completed in June 2026 (tracked in PR [#27](https://github.com/awslabs/tecli/pull/27) and follow-up PRs):
-
-- Bumped `go.mod` to **Go 1.25**.
-- Migrated `hashicorp/go-tfe` from `v0.15.0` to `v1.108.0`.
-- Refreshed all transitive dependencies (cobra, viper, logrus, testify, x/crypto, afero, go-slug, go-retryablehttp).
-- Audited and rewrote the docs (this README, [`CHANGELOG.md`](CHANGELOG.md), [`COMMANDS.md`](COMMANDS.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), and the new [`ARCHITECTURE.md`](ARCHITECTURE.md) and [`docs/RELEASING.md`](docs/RELEASING.md)).
-
-The wiki pages under <https://github.com/awslabs/tecli/wiki> were last refreshed before the modernization; some links there may describe older Go/go-tfe versions.
-
-## 🔗 References
-
-- [Terraform Cloud](https://www.terraform.io/docs/cloud/index.html) - Terraform Cloud is an application that helps teams use Terraform together.
-- [Terraform Cloud/Enterprise Go Client](https://github.com/hashicorp/go-tfe) - The official Go API client for Terraform Cloud/Enterprise (v1.108+ as of the modernization).
-- [clencli](https://github.com/awslabs/clencli) - Cloud Engineer CLI
-- [terminalizer](https://github.com/faressoft/terminalizer) - Record your terminal and generate animated gif images or share a web player link terminalizer.com
-
-## 📄 License
-
-This project is licensed under the Apache License 2.0. For more information, please read [LICENSE](LICENSE).
+This project is licensed under the Apache License 2.0. See [LICENSE](LICENSE).
 
 ---
 
-```
+```text
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ```
-
-> Photo by [Gabriel Menchaca](https://unsplash.com/gabrielmenchaca) on [Unsplash](https://unsplash.com)

--- a/TIPS.md
+++ b/TIPS.md
@@ -1,29 +1,57 @@
-## How-To
+# Tips
 
-### Create a workspace linked with a VCS repository
+This page collects task-oriented recipes that combine several TECLI commands. For the full command reference, see [COMMANDS.md](COMMANDS.md). For the most common single commands, see [TOP-COMMANDS.md](TOP-COMMANDS.md).
 
+All examples read the organization and tokens from the active profile or the `TFC_*` environment variables. See [Configuration](README.md#configuration).
+
+## Create a workspace linked to a VCS repository
+
+1. List the OAuth tokens to find the token ID for your VCS connection:
+
+```bash
+tecli o-auth-token list
 ```
-tecli oauth list --organization terraform-cloud-pipeline
-tecli workspace create --vcs-repo-oauth-token-id=ot-XXX --vcs-repo-identifier=valter-silva-au/terraform-dummy --organization=terraform-cloud-pipeline --name terraform-dummy-1
+
+2. Create the workspace and pass the OAuth token ID and repository identifier:
+
+```bash
+tecli workspace create \
+  --name terraform-dummy-1 \
+  --vcs-repo-oauth-token-id ot-XXXXXXXX \
+  --vcs-repo-identifier valter-silva-au/terraform-dummy
 ```
 
-### Create a plan and apply
+## Create a plan and apply
 
+1. Find the workspace ID:
+
+```bash
+tecli workspace list
 ```
-# Get the workspace ID you want to manage
-tecli workspace list --organization=terraform-cloud-pipeline
 
-# Create a run (plan) on the workspace and get the apply ID
-tecli run create --workspace-id ws-XXX
+2. Create a run on the workspace:
 
-# Apply the run by providing the ID
-tecli run apply --id=run-XXX
+```bash
+tecli run create --workspace-id ws-XXXXXXXX --message "Plan and apply"
+```
 
-# Read the apply by providing the apply ID
-tecli apply read --id=apply-XXX
+3. Apply the run by its ID:
 
+```bash
+tecli run apply --id run-XXXXXXXX --comment "Applying changes"
+```
+
+4. Read the apply by its ID:
+
+```bash
+tecli apply read --id apply-XXXXXXXX
+```
+
+Example output:
+
+```json
 {
-  "ID": "apply-XXX",
+  "ID": "apply-XXXXXXXX",
   "LogReadURL": "https://archivist.terraform.io/v1/object/...",
   "ResourceAdditions": 0,
   "ResourceChanges": 0,
@@ -38,10 +66,17 @@ tecli apply read --id=apply-XXX
     "started-at": "2021-01-28T23:39:17Z"
   }
 }
+```
 
-# Read the apply logs
-tecli apply logs --id=apply-XXX
+5. Read the apply logs:
 
+```bash
+tecli apply logs --id apply-XXXXXXXX
+```
+
+Example output:
+
+```text
 Terraform v0.14.5
 Initializing plugins and modules...
 
@@ -50,31 +85,38 @@ Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
 Outputs:
 
 aws_region = "us-east-1"
-
 ```
 
-### List all workspaces (and display only their ID)
+## List workspace IDs only
 
-```
-tecli workspace list --organization=terraform-cloud-pipeline | grep "ID" | grep "ws-" | awk '{ print $2}' | sed 's,",,g' | sed 's/,//g'
+Filter the `list` output down to the workspace IDs:
+
+```bash
+tecli workspace list | grep "ID" | grep "ws-" | awk '{ print $2 }' | sed 's,",,g' | sed 's/,//g'
 ```
 
-### How to update o-auth-token
+## Set an OAuth token's private SSH key
 
+Pass the key with a shell variable so the multi-line value is preserved:
+
+```bash
+private_ssh_key='-----BEGIN RSA PRIVATE KEY-----
+... shortened for brevity ...
+-----END RSA PRIVATE KEY-----'
+tecli o-auth-token update --id ot-XXXXXXXX --private-ssh-key "${private_ssh_key}"
 ```
-$ private_ssh_key='-----BEGIN -----
-.. shorten for brevity
-> -----END RSA PRIVATE KEY-----
-> '
-$ tecli o-auth-token update --id=ot-XXX --private-ssh-key "${private_ssh_key}"
+
+Example output:
+
+```json
 {
-  "ID": "ot-XXX",
+  "ID": "ot-XXXXXXXX",
   "UID": "",
   "CreatedAt": "2021-01-28T22:49:10.805Z",
   "HasSSHKey": true,
   "ServiceProviderUser": "valter-silva-au",
   "OAuthClient": {
-    "ID": "oc-XXX",
+    "ID": "oc-XXXXXXXX",
     "APIURL": "",
     "CallbackURL": "",
     "ConnectPath": "",

--- a/TOP-COMMANDS.md
+++ b/TOP-COMMANDS.md
@@ -1,84 +1,83 @@
-# Top Commands
+# Top commands
 
-Hand-curated cheat sheet of the most common TECLI invocations. The
-full command surface lives in [`COMMANDS.md`](COMMANDS.md).
+This is a quick-reference cheat sheet of the most common TECLI invocations. For the full command surface, see [COMMANDS.md](COMMANDS.md).
 
-All examples assume you have a configured profile or the appropriate
-[`TFC_*` environment variables](https://github.com/awslabs/tecli/wiki/Environment-Variables)
-set. The relevant tokens depend on the operation; most workspace and
-run operations need a [team API token](https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html#team-api-tokens).
+These examples assume you have a configured profile or the matching `TFC_*` environment variables set. The organization and tokens are read from the active profile or environment, not from a command-line flag. The token you need depends on the operation; most workspace and run operations use a [team API token](https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html#team-api-tokens).
 
 ## One-time setup
 
-Either run `tecli configure create` and follow the prompts, or export:
+Run the interactive configure command, or export the environment variables.
 
 ```bash
-# Linux / macOS
+tecli configure create
+```
+
+```bash
+# Linux and macOS
 export TFC_ORGANIZATION=your-org
 export TFC_USER_TOKEN=your-user-token
 export TFC_TEAM_TOKEN=your-team-token
 export TFC_ORGANIZATION_TOKEN=your-org-token
+```
 
+```powershell
 # Windows (PowerShell)
-$Env:TFC_ORGANIZATION="your-org"
-$Env:TFC_USER_TOKEN="your-user-token"
-$Env:TFC_TEAM_TOKEN="your-team-token"
-$Env:TFC_ORGANIZATION_TOKEN="your-org-token"
+$Env:TFC_ORGANIZATION = "your-org"
+$Env:TFC_USER_TOKEN = "your-user-token"
+$Env:TFC_TEAM_TOKEN = "your-team-token"
+$Env:TFC_ORGANIZATION_TOKEN = "your-org-token"
 ```
 
-## Workspace cookbook
+## Workspaces
 
-List all workspaces in an organization:
+List all workspaces in the organization on the active profile:
 
 ```bash
-tecli workspace list -o "${TFC_ORGANIZATION}" -p "${PROFILE}"
+tecli workspace list
 ```
 
-Find a workspace by name (avoids paging through `list`):
+Find a workspace by name. This avoids paging through `list`:
 
 ```bash
-tecli workspace find-by-name \
-  --organization="${TFC_ORGANIZATION}" \
-  --name="${TFC_WORKSPACE_NAME}"
+tecli workspace find-by-name --name "${TFC_WORKSPACE_NAME}"
 ```
 
 Create a workspace and allow destroy plans:
 
 ```bash
 tecli workspace create \
-  --organization="${TFC_ORGANIZATION}" \
-  --name="${TFC_WORKSPACE_NAME}" \
+  --name "${TFC_WORKSPACE_NAME}" \
   --allow-destroy-plan=true
 ```
 
-Lock / unlock a workspace:
+Lock and unlock a workspace by ID:
 
 ```bash
-tecli workspace lock   --id="${WORKSPACE_ID}"
-tecli workspace unlock --id="${WORKSPACE_ID}"
+tecli workspace lock --id "${WORKSPACE_ID}"
+tecli workspace unlock --id "${WORKSPACE_ID}"
 ```
 
-## Run cookbook
+## Runs
 
 Upload a configuration and create a run:
 
 ```bash
-tecli configuration-version create --workspace-id="${WORKSPACE_ID}"
-tecli configuration-version upload  --url="${CV_UPLOAD_URL}" --path=./
-tecli run create --workspace-id="${WORKSPACE_ID}" --comment="${COMMENT}"
+tecli configuration-version create --workspace-id "${WORKSPACE_ID}"
+tecli configuration-version upload --url "${CV_UPLOAD_URL}" --path ./
+tecli run create --workspace-id "${WORKSPACE_ID}" --message "${MESSAGE}"
 ```
 
-Check run status:
+Read a run's status:
 
 ```bash
-tecli run read --id="${RUN_ID}"
+tecli run read --id "${RUN_ID}"
 ```
 
-Poll until the run finishes (bash one-liner):
+Poll until the run leaves the pending state:
 
 ```bash
 while true; do
-  STATUS=$(tecli run read --id="${RUN_ID}" | jq -r ".Status")
+  STATUS=$(tecli run read --id "${RUN_ID}" | jq -r ".Status")
   if [ "${STATUS}" != "pending" ]; then
     break
   else
@@ -91,42 +90,42 @@ done
 Show plan logs:
 
 ```bash
-tecli plan logs --id="${PLAN_ID}"
+tecli plan logs --id "${PLAN_ID}"
 ```
 
 Create a destroy run:
 
 ```bash
 tecli run create \
-  --workspace-id="${WORKSPACE_ID}" \
-  --comment="${COMMENT}" \
+  --workspace-id "${WORKSPACE_ID}" \
+  --message "${MESSAGE}" \
   --is-destroy=true
 ```
 
-Discard a single run, or discard everything queued on a workspace:
+Discard one run, or discard everything queued on a workspace:
 
 ```bash
-tecli run discard     --id="${RUN_ID}"
-tecli run discard-all --workspace-id="${WORKSPACE_ID}"
+tecli run discard --id "${RUN_ID}"
+tecli run discard-all --workspace-id "${WORKSPACE_ID}"
 ```
 
-Apply a run and stream the apply logs:
+Apply a run and read the apply logs:
 
 ```bash
-tecli run apply --id="${RUN_ID}" --comment="${COMMENT}"
-tecli apply logs --id="${APPLY_ID}"
+tecli run apply --id "${RUN_ID}" --comment "${COMMENT}"
+tecli apply logs --id "${APPLY_ID}"
 ```
 
-## Variable cookbook
+## Variables
 
 Create a sensitive Terraform variable:
 
 ```bash
 tecli variable create \
-  --key="${VARIABLE_KEY}" \
-  --value="${VARIABLE_VALUE}" \
-  --workspace-id="${WORKSPACE_ID}" \
-  --category=terraform \
+  --workspace-id "${WORKSPACE_ID}" \
+  --key "${VARIABLE_KEY}" \
+  --value "${VARIABLE_VALUE}" \
+  --category terraform \
   --sensitive=true
 ```
 
@@ -134,58 +133,58 @@ Create a sensitive environment variable:
 
 ```bash
 tecli variable create \
-  --key="${VARIABLE_KEY}" \
-  --value="${VARIABLE_VALUE}" \
-  --workspace-id="${WORKSPACE_ID}" \
-  --category=env \
+  --workspace-id "${WORKSPACE_ID}" \
+  --key "${VARIABLE_KEY}" \
+  --value "${VARIABLE_VALUE}" \
+  --category env \
   --sensitive=true
 ```
 
-Bulk-load AWS credentials as env-category variables:
+Load AWS credentials as environment-category variables:
 
 ```bash
-tecli variable create --key=AWS_ACCESS_KEY_ID     --value="${AWS_ACCESS_KEY_ID}"     --workspace-id="${WORKSPACE_ID}" --category=env --sensitive=true
-tecli variable create --key=AWS_SECRET_ACCESS_KEY --value="${AWS_SECRET_ACCESS_KEY}" --workspace-id="${WORKSPACE_ID}" --category=env --sensitive=true
-tecli variable create --key=AWS_DEFAULT_REGION    --value="${AWS_DEFAULT_REGION}"    --workspace-id="${WORKSPACE_ID}" --category=env --sensitive=true
+tecli variable create --workspace-id "${WORKSPACE_ID}" --key AWS_ACCESS_KEY_ID     --value "${AWS_ACCESS_KEY_ID}"     --category env --sensitive=true
+tecli variable create --workspace-id "${WORKSPACE_ID}" --key AWS_SECRET_ACCESS_KEY --value "${AWS_SECRET_ACCESS_KEY}" --category env --sensitive=true
+tecli variable create --workspace-id "${WORKSPACE_ID}" --key AWS_DEFAULT_REGION    --value "${AWS_DEFAULT_REGION}"    --category env --sensitive=true
 
-# If you also need a session token:
-tecli variable create --key=AWS_SESSION_TOKEN --value="${AWS_SESSION_TOKEN}" --workspace-id="${WORKSPACE_ID}" --category=env --sensitive=true
+# Add a session token if you use temporary credentials
+tecli variable create --workspace-id "${WORKSPACE_ID}" --key AWS_SESSION_TOKEN --value "${AWS_SESSION_TOKEN}" --category env --sensitive=true
 ```
 
-Update an existing variable by its key (instead of by ID):
+Update a variable by its key instead of by ID:
 
 ```bash
 tecli variable update-by-key \
-  --key="${VARIABLE_KEY}" \
-  --value="${VARIABLE_VALUE}" \
-  --workspace-id="${WORKSPACE_ID}"
+  --workspace-id "${WORKSPACE_ID}" \
+  --key "${VARIABLE_KEY}" \
+  --value "${VARIABLE_VALUE}"
 ```
 
-Wipe every variable on a workspace (irreversible):
+Delete every variable on a workspace. This is irreversible:
 
 ```bash
-tecli variable delete-all --workspace-id="${WORKSPACE_ID}"
+tecli variable delete-all --workspace-id "${WORKSPACE_ID}"
 ```
 
-## VCS / OAuth cookbook
+## VCS and OAuth
 
-List OAuth tokens (used to wire workspaces to a VCS repo):
+List OAuth tokens to find the token ID for a workspace VCS connection:
 
 ```bash
-tecli o-auth-token list --organization="${TFC_ORGANIZATION}"
+tecli o-auth-token list
 ```
 
-Update an OAuth token's private SSH key (heredoc-friendly):
+Set an OAuth token's private SSH key:
 
 ```bash
 private_ssh_key="$(cat ~/.ssh/id_rsa)"
-tecli o-auth-token update --id="${OAUTH_TOKEN_ID}" --private-ssh-key "${private_ssh_key}"
+tecli o-auth-token update --id "${OAUTH_TOKEN_ID}" --private-ssh-key "${private_ssh_key}"
 ```
 
-Manage the OAuth client itself:
+Manage the OAuth client:
 
 ```bash
-tecli o-auth-client list   --organization="${TFC_ORGANIZATION}"
-tecli o-auth-client read   --id="${OAUTH_CLIENT_ID}"
-tecli o-auth-client delete --id="${OAUTH_CLIENT_ID}"
+tecli o-auth-client list
+tecli o-auth-client read   --id "${OAUTH_CLIENT_ID}"
+tecli o-auth-client delete --id "${OAUTH_CLIENT_ID}"
 ```


### PR DESCRIPTION
## Summary

Rewrites the TECLI technical documentation to the shared AWS documentation style so it reads as one voice across the AWS OSS fleet: second-person, present-tense, task-oriented prose; sentence-case headings; language-hinted code blocks; and the required README section order. All content was verified against the Go source (`cobra/controller/`, `cobra/aid/`, `cobra/dao/`, `main.go`, `go.mod`); where the docs and the code disagreed, the code won.

## Files changed

- **README.md** — restructured to the required order: Overview, Features, Prerequisites, Installation, Getting started, Usage, Configuration, Architecture, Troubleshooting, Contributing, Security, License.
- **ARCHITECTURE.md** — components, data flow, and design decisions; one-directional layering and credential resolution documented.
- **COMMANDS.md** — full per-command reference (synopsis, description, flags table, examples), one section per command, verified against the `*ValidArgs` slices and `SetXxxFlags` definitions.
- **TOP-COMMANDS.md** — restyled quick-reference cookbook (kept its cheat-sheet role).
- **TIPS.md** — restyled task recipes.

## Accuracy corrections

- Removed the non-existent `--organization`/`-o` flag from all examples. The organization and tokens are read from the `TFC_*` environment variables or the active credentials profile, never from a command-line flag (`cobra/dao/configure.go`).
- `run create` uses `--message` for the run message (not `--comment`). `--comment` applies to `apply`, `cancel`, `force-cancel`, and `discard`.
- Documented the credentials file as `credentials.yaml` under the OS user config directory (for example, `~/Library/Application Support/tecli/` on macOS, `~/.config/tecli/` on Linux), not `~/.tecli/`.
- Replaced the non-existent `tecli oauth` command with the real `o-auth-token` and `o-auth-client` commands.

## Compliance

Compliance files (LICENSE, NOTICE, SECURITY.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, CHANGELOG.md, CODEOWNERS) were not modified. No branch protections or repository settings were changed.
