### PR TITLE
docs: add mermaid diagrams

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,9 +12,39 @@ The command framework is [Cobra](https://github.com/spf13/cobra). Configuration 
 
 The dependency direction flows in one direction, from the command adapters down to the API client:
 
-```text
-cobra/cmd  -->  cobra/controller  -->  cobra/aid  -->  helper/, box/
-                                  -->  hashicorp/go-tfe
+```mermaid
+%% Component and dependency diagram
+flowchart TB
+    user([You / CI pipeline])
+
+    subgraph cli["tecli binary"]
+        main["main.go<br/>cmd.Execute()"]
+        cmd["cobra/cmd<br/>thin command adapters"]
+        controller["cobra/controller<br/>business logic, PreRunE / RunE"]
+        aid["cobra/aid<br/>flag builders, TFE client, Viper"]
+        dao["cobra/dao<br/>resolve org and tokens"]
+        view["cobra/view<br/>interactive prompts"]
+        helperbox["helper/, box/<br/>utilities and embedded manuals"]
+    end
+
+    gotfe["hashicorp/go-tfe<br/>Go client"]
+    tfc[("Terraform Cloud / Enterprise API")]
+
+    creds["credentials.yaml<br/>under os.UserConfigDir()"]
+    env["TFC_* environment variables"]
+
+    user --> cmd
+    main --> cmd
+    cmd --> controller
+    controller --> aid
+    controller --> dao
+    controller --> view
+    controller --> gotfe
+    aid --> helperbox
+    aid --> gotfe
+    dao --> creds
+    env --> dao
+    gotfe --> tfc
 ```
 
 Layers below `controller` do not import `cmd`. Layers below `aid` do not import `controller`.
@@ -45,6 +75,37 @@ A single command, such as `tecli workspace list`, flows through the layers:
 3. The matched controller runs `PreRunE` to validate the argument and its required flags.
 4. `RunE` reads the resolved token through `cobra/dao` (environment variable first, then the active profile), builds a `*tfe.Client` with `aid.GetTFEClient`, and calls the matching `go-tfe` method.
 5. The controller prints the API response as JSON.
+
+The following sequence shows `tecli workspace create --name my-workspace`:
+
+```mermaid
+%% Sequence for tecli workspace create
+sequenceDiagram
+    actor User
+    participant Cmd as cobra/cmd
+    participant Ctrl as cobra/controller
+    participant Aid as cobra/aid
+    participant Dao as cobra/dao
+    participant Tfe as hashicorp/go-tfe
+    participant TFC as Terraform Cloud API
+
+    User->>Cmd: tecli workspace create --name my-workspace
+    Cmd->>Ctrl: run matched command (initConfig loads Viper)
+    Ctrl->>Ctrl: PreRunE validates argument and --name flag
+    Ctrl->>Dao: GetOrganizationToken(profile)
+    Dao-->>Ctrl: token (TFC_* env var, else profile)
+    Ctrl->>Aid: GetTFEClient(token)
+    Aid-->>Ctrl: *tfe.Client
+    Ctrl->>Dao: GetOrganization(profile)
+    Dao-->>Ctrl: organization
+    Ctrl->>Aid: GetWorkspaceCreateOptions(cmd)
+    Aid-->>Ctrl: tfe.WorkspaceCreateOptions
+    Ctrl->>Tfe: Workspaces.Create(ctx, organization, options)
+    Tfe->>TFC: POST /organizations/{org}/workspaces
+    TFC-->>Tfe: workspace JSON
+    Tfe-->>Ctrl: *tfe.Workspace
+    Ctrl-->>User: print workspace as JSON
+```
 
 ## Design decisions
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,21 @@ The `configure` command reads and writes the credentials file only. It does not 
 
 ## Architecture
 
-TECLI is a thin command-line wrapper around `hashicorp/go-tfe`. The `main` package calls `cmd.Execute()`, which builds a Cobra command tree. Each command validates flags, marshals them into `go-tfe` option structs, calls the Terraform Cloud API, and prints the JSON response. For components, data flow, and design decisions, see [ARCHITECTURE.md](ARCHITECTURE.md).
+TECLI is a thin command-line wrapper around `hashicorp/go-tfe`. The `main` package calls `cmd.Execute()`, which builds a Cobra command tree. Each command validates flags, marshals them into `go-tfe` option structs, calls the Terraform Cloud API, and prints the JSON response.
+
+```mermaid
+%% High-level request flow
+flowchart LR
+    user([You / CI pipeline]) --> cli["tecli<br/>Cobra command"]
+    cli --> resolve["Resolve org and token<br/>TFC_* env vars, then profile"]
+    config[("credentials.yaml<br/>+ TFC_* env vars")] --> resolve
+    resolve --> gotfe["hashicorp/go-tfe<br/>client"]
+    gotfe --> tfc[("Terraform Cloud /<br/>Enterprise API")]
+    tfc --> gotfe
+    gotfe --> out["JSON response<br/>printed to stdout"]
+```
+
+For components, data flow, and design decisions, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What

Adds Mermaid diagrams to the TECLI documentation. GitHub renders ` ```mermaid ` fenced blocks natively, so these appear inline on the rendered pages.

## Diagrams added

- **ARCHITECTURE.md — component/dependency diagram** (Components section): shows the one-directional dependency flow `cobra/cmd` -> `cobra/controller` -> `cobra/aid` / `cobra/dao` / `cobra/view` -> `hashicorp/go-tfe` -> Terraform Cloud/Enterprise API, with `credentials.yaml` (under `os.UserConfigDir()`) and `TFC_*` environment variables feeding token/organization resolution.
- **ARCHITECTURE.md — sequence diagram** (Data flow section): traces `tecli workspace create` through `cmd` -> `controller` (PreRunE validation, RunE) -> `dao` (token/org, env-first) -> `aid` (TFE client, options) -> `go-tfe` -> the TFC API and back to the printed JSON.
- **README.md — overview flow diagram** (Architecture section): high-level request flow from the user/CI pipeline through credential resolution, the `go-tfe` client, the TFC API, and the JSON response on stdout.

The diagrams reflect the actual code structure (verified against `main.go`, `cobra/cmd`, `cobra/controller`, `cobra/aid`, `cobra/dao`, and `go.mod`); no layers were invented.

## Validation

All mermaid diagrams validated locally with mermaid-cli.

## Safety

Compliance files not modified.
No branch protections or settings changed.
